### PR TITLE
Once again enable build of qmlwidgets

### DIFF
--- a/libqf/plugins/plugins.pro
+++ b/libqf/plugins/plugins.pro
@@ -3,7 +3,7 @@ CONFIG += ordered
 
 SUBDIRS += \
 	core \
-	#qmlwidgets \ qmlwidgets plugin excluded from build till QTBUG-39477 will be fixed
+	qmlwidgets \ # cannot be removed, Windows cannot load qml module (all includes this one)
 	qmlreports \
 
 


### PR DESCRIPTION
Because all of QML modules import this module.
So they didn't load when qmlwidgets are disabled from build.
Tested only on Windows.