### PR TITLE
Fix of bad loss times on receipts

### DIFF
--- a/quickevent/app/plugins/qml/Receipts/src/Receipts/receiptsplugin.cpp
+++ b/quickevent/app/plugins/qml/Receipts/src/Receipts/receiptsplugin.cpp
@@ -243,7 +243,7 @@ QVariantMap ReceiptsPlugin::receiptTablesData(int card_id)
 			int lap = punch.lapTimeMs();
 			ttr.setValue("lapTimeMs", lap);
 			int best_lap = best_laps.value(pos);
-			if(best_lap > 0) {
+			if(lap > 0 && best_lap > 0) {
 				int loss = lap - best_lap;
 				ttr.setValue("lossMs", loss);
 			}


### PR DESCRIPTION
This fixes printing bad loss time on receipts after missing punch. (issue #54 )