### PR TITLE
Fix of non-autosend readout

### DIFF
--- a/libsiut/src/device/sidevicedriver.cpp
+++ b/libsiut/src/device/sidevicedriver.cpp
@@ -69,6 +69,9 @@ void DeviceDriver::commDataReceived()
 			f_rxTimer->stop();
 			if(f_status == StatusMessageOk) {
 				//qfInfo() << "new message:" << f_messageData.dump();
+				if(f_messageData.type() == SIMessageData::MsgCardReadOut) {
+					sendAck();
+				}
 				emit messageReady(f_messageData);
 				f_messageData = SIMessageData();
 			}
@@ -101,7 +104,7 @@ namespace
 {
 static const char STX = 0x02;
 static const char ETX = 0x03;
-//static const char ACK = 0x06;
+static const char ACK = 0x06;
 static const char NAK = 0x15;
 static const char DLE = 0x10;
 }
@@ -326,4 +329,9 @@ void DeviceDriver::sendCommand(int cmd, const QByteArray& data)
 		qfInfo() << "sending command:" << SIMessageData::dumpData(ba);
 		f_commPort->write(ba);
 	}
+}
+
+void DeviceDriver::sendAck() 
+{
+	f_commPort->write(QByteArray(1, ACK));
 }

--- a/libsiut/src/device/sidevicedriver.h
+++ b/libsiut/src/device/sidevicedriver.h
@@ -54,6 +54,9 @@ signals:
 public:
 	DeviceDriver(QObject *parent = NULL);
 	virtual ~DeviceDriver();
+
+private:
+	void sendAck();
 };
 
 }

--- a/quickevent/app/plugins/qml/CardReader/src/cardreaderwidget.cpp
+++ b/quickevent/app/plugins/qml/CardReader/src/cardreaderwidget.cpp
@@ -348,21 +348,13 @@ void CardReaderWidget::processSIMessage(const SIMessageData& msg_data)
 	else if(msg_data.type() == SIMessageData::MsgCardEvent) {
 		appendLog(qf::core::Log::Level::Debug, msg_data.dump());
 		if(msg_data.command() == SIMessageData::CmdSICard5DetectedExt) {
-			QByteArray data(1, 0);
-			data[0] = 0;
-			emit sendSICommand(SIMessageData::CmdGetSICard5Ext, data);
+			emit sendSICommand(SIMessageData::CmdGetSICard5Ext, QByteArray());
 		}
 		else if(msg_data.command() == SIMessageData::CmdSICard6DetectedExt) {
-			QByteArray data(2, 0);
-			data[0] = 1;
-			data[1] = 8;
-			emit sendSICommand(SIMessageData::CmdGetSICard6Ext, data);
+			emit sendSICommand(SIMessageData::CmdGetSICard6Ext, QByteArray("\x08", 1));
 		}
 		else if(msg_data.command() == SIMessageData::CmdSICard8AndHigherDetectedExt) {
-			QByteArray data(2, 0);
-			data[0] = 1;
-			data[1] = 8;
-			emit sendSICommand(SIMessageData::CmdGetSICard8Ext, data);
+			emit sendSICommand(SIMessageData::CmdGetSICard8Ext, QByteArray("\x08", 1));
 		}
 	}
 	else if(msg_data.type() == SIMessageData::MsgPunch) {


### PR DESCRIPTION
Tak zde je ta slíbená oprava vyčítání bez zapnutého auto send. Přidal jsem tam ještě posílání ACK po úspěšném vyčtení, aby ta krabička zapípala.

Testoval jsem to pro čipy verze 5 a 6. Ještě by to radši měl někdo vyzkoušet u čipů verze 8/9 a 10/11. Podle dokumentace by to takto fungovat mělo, ale jistota je jistota.