### PR TITLE
3 nové režimy losování

### DIFF
--- a/quickevent/app/plugins/qml/Runs/src/runstablewidget.cpp
+++ b/quickevent/app/plugins/qml/Runs/src/runstablewidget.cpp
@@ -63,6 +63,7 @@ RunsTableWidget::RunsTableWidget(QWidget *parent) :
 	m->addColumn("competitors.siId", tr("SI"));
 	m->addColumn("competitorName", tr("Name"));
 	m->addColumn("registration", tr("Reg"));
+	m->addColumn("licence", tr("Lic"));
 	m->addColumn("runs.siId", tr("SI")).setCastType(qMetaTypeId<quickevent::og::SiId>());
 	m->addColumn("runs.startTimeMs", tr("Start")).setCastType(qMetaTypeId<quickevent::og::TimeMs>());
 	m->addColumn("runs.timeMs", tr("Time")).setCastType(qMetaTypeId<quickevent::og::TimeMs>());
@@ -122,7 +123,7 @@ void RunsTableWidget::reload(int stage_id, int class_id, const QString &sort_col
 	qfLogFuncFrame();
 	qfs::QueryBuilder qb;
 	qb.select2("runs", "*")
-			.select2("competitors", "registration, siId, note")
+			.select2("competitors", "registration, licence, siId, note")
 			.select2("classes", "name")
 			.select("COALESCE(lastName, '') || ' ' || COALESCE(firstName, '') AS competitorName")
 			.from("runs")

--- a/quickevent/app/plugins/qml/Runs/src/runstablewidget.cpp
+++ b/quickevent/app/plugins/qml/Runs/src/runstablewidget.cpp
@@ -64,7 +64,8 @@ RunsTableWidget::RunsTableWidget(QWidget *parent) :
 	m->addColumn("competitorName", tr("Name"));
 	m->addColumn("registration", tr("Reg"));
 	m->addColumn("licence", tr("Lic"));
-	m->addColumn("runs.siId", tr("SI")).setCastType(qMetaTypeId<quickevent::og::SiId>());
+    m->addColumn("ranking", tr("Rank"));
+    m->addColumn("runs.siId", tr("SI")).setCastType(qMetaTypeId<quickevent::og::SiId>());
 	m->addColumn("runs.startTimeMs", tr("Start")).setCastType(qMetaTypeId<quickevent::og::TimeMs>());
 	m->addColumn("runs.timeMs", tr("Time")).setCastType(qMetaTypeId<quickevent::og::TimeMs>());
 	//m->addColumn("runs.timeMs", tr("Time raw"));
@@ -123,7 +124,7 @@ void RunsTableWidget::reload(int stage_id, int class_id, const QString &sort_col
 	qfLogFuncFrame();
 	qfs::QueryBuilder qb;
 	qb.select2("runs", "*")
-			.select2("competitors", "registration, licence, siId, note")
+            .select2("competitors", "registration, licence, ranking, siId, note")
 			.select2("classes", "name")
 			.select("COALESCE(lastName, '') || ' ' || COALESCE(firstName, '') AS competitorName")
 			.from("runs")

--- a/quickevent/app/plugins/qml/Runs/src/runstablewidget.cpp
+++ b/quickevent/app/plugins/qml/Runs/src/runstablewidget.cpp
@@ -63,10 +63,10 @@ RunsTableWidget::RunsTableWidget(QWidget *parent) :
 	m->addColumn("competitors.siId", tr("SI"));
 	m->addColumn("competitorName", tr("Name"));
 	m->addColumn("registration", tr("Reg"));
-	m->addColumn("licence", tr("Lic"));
-    m->addColumn("ranking", tr("Rank"));
+    m->addColumn("licence", tr("Lic")).setToolTip(tr("Licence"));
+    m->addColumn("ranking", tr("Rank")).setToolTip(tr("Ranking"));
     m->addColumn("runs.siId", tr("SI")).setCastType(qMetaTypeId<quickevent::og::SiId>());
-	m->addColumn("runs.startTimeMs", tr("Start")).setCastType(qMetaTypeId<quickevent::og::TimeMs>());
+    m->addColumn("runs.startTimeMs", tr("Start")).setCastType(qMetaTypeId<quickevent::og::TimeMs>()).setToolTip(tr("Start time. Colors: red = duplicate, lime = same clubs together, green = vacant space before"));
 	m->addColumn("runs.timeMs", tr("Time")).setCastType(qMetaTypeId<quickevent::og::TimeMs>());
 	//m->addColumn("runs.timeMs", tr("Time raw"));
 	m->addColumn("runs.finishTimeMs", tr("Finish")).setCastType(qMetaTypeId<quickevent::og::TimeMs>());

--- a/quickevent/app/plugins/qml/Runs/src/runswidget.cpp
+++ b/quickevent/app/plugins/qml/Runs/src/runswidget.cpp
@@ -244,10 +244,10 @@ QList<int> RunsWidget::runsForClass(int stage_id, int class_id)
 	return ret;
 }
 
-QList<int> RunsWidget::runsForClassCondition(int stage_id, int class_id, QString condition)
+QList<int> RunsWidget::runsForClass(int stage_id, int class_id, const QString &extra_condition)
 {
         qfLogFuncFrame();
-        QList<int> ret = competitorsForClassCondition(stage_id, class_id, condition).values();
+		QList<int> ret = competitorsForClass(stage_id, class_id, extra_condition).values();
         return ret;
 }
 
@@ -261,7 +261,7 @@ qf::core::sql::QueryBuilder competitorBaseQuery(int stage_id, int class_id)
     return qb;
 }
 
-QMap<int, int> RunsWidget::runCompetitorQuery(QString query)
+QMap<int, int> RunsWidget::runCompetitorQuery(const QString &query)
 {
     QMap<int, int> ret;
     qfs::Query q;
@@ -280,12 +280,11 @@ QMap<int, int> RunsWidget::competitorsForClass(int stage_id, int class_id)
 }
 
 
-QMap<int, int> RunsWidget::competitorsForClassCondition(int stage_id, int class_id, QString condition)
+QMap<int, int> RunsWidget::competitorsForClass(int stage_id, int class_id, const QString &extra_condition)
 {
         qfLogFuncFrame();
-        QMap<int, int> ret;
-        qf::core::sql::QueryBuilder qb = competitorBaseQuery(stage_id, class_id)
-                        .where(condition);
+		qf::core::sql::QueryBuilder qb = competitorBaseQuery(stage_id, class_id)
+						.where(extra_condition);
         return runCompetitorQuery(qb.toString());
 }
 
@@ -447,25 +446,25 @@ void RunsWidget::on_btDraw_clicked()
 				shuffle(runners_draw_ids);
 			}
             else if(draw_method == DrawMethod::GroupedC) {
-                QList<int> group1 = runsForClassCondition(stage_id, class_id, "licence='C' or licence is null");
-                QList<int> group2 = runsForClassCondition(stage_id, class_id, "licence='A' or licence='B'");
+				QList<int> group1 = runsForClass(stage_id, class_id, "licence='C' or licence is null");
+				QList<int> group2 = runsForClass(stage_id, class_id, "licence='A' or licence='B'");
                 shuffle(group1);
                 shuffle(group2);
                 runners_draw_ids = group1 + group2;
             }
             else if(draw_method == DrawMethod::GroupedCB) {
-                QList<int> group1 = runsForClassCondition(stage_id, class_id, "licence='C' or licence is null");
-                QList<int> group2 = runsForClassCondition(stage_id, class_id, "licence='B'");
-                QList<int> group3 = runsForClassCondition(stage_id, class_id, "licence='A' or licence='R' or licence='E'");
+				QList<int> group1 = runsForClass(stage_id, class_id, "licence='C' or licence is null");
+				QList<int> group2 = runsForClass(stage_id, class_id, "licence='B'");
+				QList<int> group3 = runsForClass(stage_id, class_id, "licence='A' or licence='R' or licence='E'");
                 shuffle(group1);
                 shuffle(group2);
                 shuffle(group3);
                 runners_draw_ids = group1 + group2 + group3;
             }
             else if(draw_method == DrawMethod::GroupedRanking) {
-                QList<int> group1 = runsForClassCondition(stage_id, class_id, "ranking>300 or ranking is null");
-                QList<int> group2 = runsForClassCondition(stage_id, class_id, "ranking>100 and ranking<=300");
-                QList<int> group3 = runsForClassCondition(stage_id, class_id, "ranking<=100");
+				QList<int> group1 = runsForClass(stage_id, class_id, "ranking>300 or ranking is null");
+				QList<int> group2 = runsForClass(stage_id, class_id, "ranking>100 and ranking<=300");
+				QList<int> group3 = runsForClass(stage_id, class_id, "ranking<=100");
                 shuffle(group1);
                 shuffle(group2);
                 shuffle(group3);

--- a/quickevent/app/plugins/qml/Runs/src/runswidget.cpp
+++ b/quickevent/app/plugins/qml/Runs/src/runswidget.cpp
@@ -48,7 +48,10 @@ RunsWidget::RunsWidget(QWidget *parent) :
 
 	ui->cbxDrawMethod->addItem(tr("Randomized equidistant clubs"), static_cast<int>(DrawMethod::RandomizedEquidistantClubs));
 	ui->cbxDrawMethod->addItem(tr("Random number"), static_cast<int>(DrawMethod::RandomNumber));
-	ui->cbxDrawMethod->addItem(tr("Equidistant clubs"), static_cast<int>(DrawMethod::EquidistantClubs));
+    ui->cbxDrawMethod->addItem(tr("Grouped: C, B+A"), static_cast<int>(DrawMethod::GroupedC));
+    ui->cbxDrawMethod->addItem(tr("Grouped: C, B, A+E+R"), static_cast<int>(DrawMethod::GroupedCB));
+    ui->cbxDrawMethod->addItem(tr("Grouped by ranking"), static_cast<int>(DrawMethod::GroupedRanking));
+    ui->cbxDrawMethod->addItem(tr("Equidistant clubs"), static_cast<int>(DrawMethod::EquidistantClubs));
 	ui->cbxDrawMethod->addItem(tr("Stage 1 reverse order"), static_cast<int>(DrawMethod::StageReverseOrder));
 	ui->cbxDrawMethod->addItem(tr("Handicap"), static_cast<int>(DrawMethod::Handicap));
 	ui->frmDrawing->setVisible(false);
@@ -241,21 +244,49 @@ QList<int> RunsWidget::runsForClass(int stage_id, int class_id)
 	return ret;
 }
 
+QList<int> RunsWidget::runsForClassCondition(int stage_id, int class_id, QString condition)
+{
+        qfLogFuncFrame();
+        QList<int> ret = competitorsForClassCondition(stage_id, class_id, condition).values();
+        return ret;
+}
+
+qf::core::sql::QueryBuilder competitorBaseQuery(int stage_id, int class_id)
+{
+    qf::core::sql::QueryBuilder qb;
+    qb.select2("runs", "id, competitorId")
+            .from("competitors")
+            .joinRestricted("competitors.id", "runs.competitorId", "NOT runs.offRace AND runs.stageId=" QF_IARG(stage_id), "JOIN")
+            .where("competitors.classId=" QF_IARG(class_id));
+    return qb;
+}
+
+QMap<int, int> RunsWidget::runCompetitorQuery(QString query)
+{
+    QMap<int, int> ret;
+    qfs::Query q;
+    q.exec(query, qf::core::Exception::Throw);
+    while(q.next()) {
+        ret[q.value("competitorId").toInt()] = q.value("id").toInt();
+    }
+    return ret;
+}
+
 QMap<int, int> RunsWidget::competitorsForClass(int stage_id, int class_id)
 {
 	qfLogFuncFrame();
-	QMap<int, int> ret;
-	qf::core::sql::QueryBuilder qb;
-	qb.select2("runs", "id, competitorId")
-			.from("competitors")
-			.joinRestricted("competitors.id", "runs.competitorId", "NOT runs.offRace AND runs.stageId=" QF_IARG(stage_id), "JOIN")
-			.where("competitors.classId=" QF_IARG(class_id));
-	qfs::Query q;
-	q.exec(qb.toString(), qf::core::Exception::Throw);
-	while(q.next()) {
-		ret[q.value("competitorId").toInt()] = q.value("id").toInt();
-	}
-	return ret;
+    qf::core::sql::QueryBuilder qb = competitorBaseQuery(stage_id, class_id);
+    return runCompetitorQuery(qb.toString());
+}
+
+
+QMap<int, int> RunsWidget::competitorsForClassCondition(int stage_id, int class_id, QString condition)
+{
+        qfLogFuncFrame();
+        QMap<int, int> ret;
+        qf::core::sql::QueryBuilder qb = competitorBaseQuery(stage_id, class_id)
+                        .where(condition);
+        return runCompetitorQuery(qb.toString());
 }
 
 void RunsWidget::import_start_times_ob2000()
@@ -415,7 +446,32 @@ void RunsWidget::on_btDraw_clicked()
 				runners_draw_ids = runsForClass(stage_id, class_id);
 				shuffle(runners_draw_ids);
 			}
-			else if(draw_method == DrawMethod::Handicap) {
+            else if(draw_method == DrawMethod::GroupedC) {
+                QList<int> group1 = runsForClassCondition(stage_id, class_id, "licence='C' or licence is null");
+                QList<int> group2 = runsForClassCondition(stage_id, class_id, "licence='A' or licence='B'");
+                shuffle(group1);
+                shuffle(group2);
+                runners_draw_ids = group1 + group2;
+            }
+            else if(draw_method == DrawMethod::GroupedCB) {
+                QList<int> group1 = runsForClassCondition(stage_id, class_id, "licence='C' or licence is null");
+                QList<int> group2 = runsForClassCondition(stage_id, class_id, "licence='B'");
+                QList<int> group3 = runsForClassCondition(stage_id, class_id, "licence='A' or licence='R' or licence='E'");
+                shuffle(group1);
+                shuffle(group2);
+                shuffle(group3);
+                runners_draw_ids = group1 + group2 + group3;
+            }
+            else if(draw_method == DrawMethod::GroupedRanking) {
+                QList<int> group1 = runsForClassCondition(stage_id, class_id, "ranking>300 or ranking is null");
+                QList<int> group2 = runsForClassCondition(stage_id, class_id, "ranking>100 and ranking<=300");
+                QList<int> group3 = runsForClassCondition(stage_id, class_id, "ranking<=100");
+                shuffle(group1);
+                shuffle(group2);
+                shuffle(group3);
+                runners_draw_ids = group1 + group2 + group3;
+            }
+            else if(draw_method == DrawMethod::Handicap) {
 				int stage_count = eventPlugin()->eventConfig()->stageCount();
 				qf::core::utils::Table results = runsPlugin()->nstagesResultsTable(stage_count - 1, class_id);
 				QMap<int, int> competitor_to_run = competitorsForClass(stage_count, class_id);

--- a/quickevent/app/plugins/qml/Runs/src/runswidget.h
+++ b/quickevent/app/plugins/qml/Runs/src/runswidget.h
@@ -46,6 +46,7 @@ public:
 	Q_SIGNAL void selectedStageIdChanged(int stage_id);
 
 	//void editStartList(int class_id, int competitor_id);
+
 private slots:
 	void on_btDraw_clicked();
 	void on_btDrawRemove_clicked();
@@ -61,13 +62,26 @@ private:
 	QList< QList<int> > runnersByClubSortedByCount(int stage_id, int class_id, QMap<int, QString> &runner_id_to_club);
 	QList<int> runsForClass(int stage_id, int class_id);
 	QMap<int, int> competitorsForClass(int stage_id, int class_id);
+    QList<int> runsForClassCondition(int stage_id, int class_id, QString condition);
+    QMap<int, int> competitorsForClassCondition(int stage_id, int class_id, QString condition);
+    QMap<int, int> runCompetitorQuery(QString query);
 
 	bool isLockedForDrawing(int class_id, int stage_id);
 	void saveLockedForDrawing(int class_id, int stage_id, bool is_locked);
 
 	void import_start_times_ob2000();
 private:
-	enum class DrawMethod : int {Invalid = 0, RandomNumber, EquidistantClubs, RandomizedEquidistantClubs, StageReverseOrder, Handicap};
+    enum class DrawMethod : int {
+        Invalid = 0,
+        RandomNumber, // Completely randomly
+        EquidistantClubs,
+        RandomizedEquidistantClubs,
+        StageReverseOrder,
+        Handicap,
+        GroupedC,  // All C first, followed by B + A (H/D 12,14)
+        GroupedCB, // All C first, then B, then A + E + R
+        GroupedRanking // First group ranking >300, then 101-300, then 1-100
+    };
 
 	Ui::RunsWidget *ui;
 	qf::qmlwidgets::ForeignKeyComboBox *m_cbxClasses = nullptr;

--- a/quickevent/app/plugins/qml/Runs/src/runswidget.h
+++ b/quickevent/app/plugins/qml/Runs/src/runswidget.h
@@ -62,9 +62,9 @@ private:
 	QList< QList<int> > runnersByClubSortedByCount(int stage_id, int class_id, QMap<int, QString> &runner_id_to_club);
 	QList<int> runsForClass(int stage_id, int class_id);
 	QMap<int, int> competitorsForClass(int stage_id, int class_id);
-    QList<int> runsForClassCondition(int stage_id, int class_id, QString condition);
-    QMap<int, int> competitorsForClassCondition(int stage_id, int class_id, QString condition);
-    QMap<int, int> runCompetitorQuery(QString query);
+	QList<int> runsForClass(int stage_id, int class_id, const QString &extra_condition);
+	QMap<int, int> competitorsForClass(int stage_id, int class_id, const QString &extra_condition);
+	QMap<int, int> runCompetitorQuery(const QString &query);
 
 	bool isLockedForDrawing(int class_id, int stage_id);
 	void saveLockedForDrawing(int class_id, int stage_id, bool is_locked);


### PR DESCRIPTION
Změny potřebné pro použití na mistrovství v Pražské oblasti, ale jistě se budou hodit i později :).

Přidává 3 mody generování časů dle soutěžního řádu:
Pro HD12,14 nejprve nalosuje v kategorii C a pak zbytek
Pro HD 16 až 20 nalosuje nejprve C, pak B a pak zbytek
Pro 21 se losuje po skupionkách dle rankingu
(tyto 3 mody jsou přidány k již existujícím a je nutné je pro tu kterou kategorii vybrat).

Spolu s tím pro zjednodušení práce přibyly sloupečky s licencí a rankingem, doplnil jsem i tooltipy.

Ranking by se mohl importovat z orisu - prozatím jsem importoval skriptem přímo do DB, ale časem by se mohlo vyřešit import interně.
