### PR TITLE
eventplugin: Fix SQL statement

### DIFF
--- a/quickevent/app/plugins/qml/Event/src/Event/eventplugin.cpp
+++ b/quickevent/app/plugins/qml/Event/src/Event/eventplugin.cpp
@@ -640,7 +640,8 @@ bool EventPlugin::createEvent(const QString &event_name, const QVariantMap &even
 			if(connection_type == ConnectionType::SqlServer)
 				stage_table_name = event_id + '.' + stage_table_name;
 			QDateTime start_dt = event_config.eventDateTime();
-			q.prepare("INSERT INTO " + stage_table_name + " (id) VALUES (:id, :startDateTime)");
+			// FIXME: handle SQL errors here and below in q.exec()
+			q.prepare("INSERT INTO " + stage_table_name + " (id, startDateTime) VALUES (:id, :startDateTime)");
 			for(int i=0; i<stage_count; i++) {
 				q.bindValue(":id", i+1);
 				q.bindValue(":startDateTime", start_dt);


### PR DESCRIPTION
Commit 78865b742dd71 broke event setup sequence which manifested itself with
following messages in application debugging output:
  88<WARN>[query.cpp:30] "2 values for 1 columns Unable to execute statement"
  89<WARN>[query.cpp:60] " Parameter count mismatch"

It is disturbing that this error passed unnoticed.