### PR TITLE
Coverity scan fixes

### DIFF
--- a/libqf/libqfqmlwidgets/src/framework/mainwindow.h
+++ b/libqf/libqfqmlwidgets/src/framework/mainwindow.h
@@ -99,7 +99,6 @@ private:
 	//void setupSettingsPersistence();
 private:
 	PluginLoader *m_pluginLoader;
-	qf::qmlwidgets::StatusBar* m_statusBar;
 	QMap<QString, qf::qmlwidgets::ToolBar*> m_toolBars;
 	static MainWindow *self;
 };

--- a/libqf/libqfqmlwidgets/src/framework/partswitch.cpp
+++ b/libqf/libqfqmlwidgets/src/framework/partswitch.cpp
@@ -76,7 +76,7 @@ void PartSwitch::addPartWidget(PartWidget *widget)
 void PartSwitch::updateButtonIcon(PartSwitchToolButton *bt)
 {
 	PartWidget *pw = m_centralWidget->partWidget(bt->partIndex());
-	if(bt && pw) {
+	if(pw) {
 		QIcon ico = pw->createIcon();
 		//bt->setIconSize(bt->size());
 		bt->setIcon(ico);

--- a/libqf/libqfqmlwidgets/src/reports/processor/reportitemimage.cpp
+++ b/libqf/libqfqmlwidgets/src/reports/processor/reportitemimage.cpp
@@ -322,7 +322,7 @@ ReportItemImage::PrintResult ReportItemImage::printMetaPaintChildren(ReportItemM
 				if(w > 0 && w < br.width())
 					br.setWidth(w);
 				if(h > 0 && h < br.height())
-					br.setHeight(w);
+					br.setHeight(h);
 				//qfInfo() << "image bounding rect w:" << w << "h:" << h << "designed rect:" << designedRect.toString();
 			}
 			else if(im.isPicture()) {

--- a/libsiut/src/device/sidevicedriver.cpp
+++ b/libsiut/src/device/sidevicedriver.cpp
@@ -22,7 +22,7 @@ using namespace siut;
 //             DeviceDriver
 //=================================================
 DeviceDriver::DeviceDriver(QObject *parent)
-	: Super(parent)
+	: Super(parent), f_packetToFinishCount()
 {
 	qf::core::Log::checkLogLevelMetaTypeRegistered();
 	f_commPort = new CommPort(this);

--- a/quickevent/app/plugins/qml/Classes/src/editcoursecodeswidget.cpp
+++ b/quickevent/app/plugins/qml/Classes/src/editcoursecodeswidget.cpp
@@ -18,7 +18,7 @@ namespace qfm = qf::core::model;
 namespace qfs = qf::core::sql;
 
 EditCourseCodesWidget::EditCourseCodesWidget(QWidget *parent)
-	: Super(parent)
+	: Super(parent), m_courseId()
 	, ui(new Ui::EditCourseCodesWidget)
 {
 	setPersistentSettingsId("EditCourseCodesWidget");

--- a/quickevent/app/plugins/qml/Runs/src/drawing/ganttscene.cpp
+++ b/quickevent/app/plugins/qml/Runs/src/drawing/ganttscene.cpp
@@ -6,7 +6,7 @@
 using namespace drawing;
 
 GanttScene::GanttScene(QObject * parent)
-	: Super(parent)
+	: Super(parent), m_ganttItem()
 {
 	setDisplayUnit(QFontMetrics(QFont()).lineSpacing() / 2);
 

--- a/quickevent/app/plugins/qml/Runs/src/runstableitemdelegate.cpp
+++ b/quickevent/app/plugins/qml/Runs/src/runstableitemdelegate.cpp
@@ -18,7 +18,7 @@
 namespace qfs = qf::core::sql;
 
 RunsTableItemDelegate::RunsTableItemDelegate(qf::qmlwidgets::TableView * parent)
-	: Super(parent)
+	: Super(parent), m_classStart(), m_classInterval()
 {
 }
 

--- a/quickevent/app/src/main.cpp
+++ b/quickevent/app/src/main.cpp
@@ -55,6 +55,7 @@ int main(int argc, char *argv[])
 		qDebug() << "Undefined argument:" << s;
 	}
 
+    // Uncaught exception is intentional here
 	if(!cli_opts.loadConfigFile()) {
 		return EXIT_FAILURE;
 	}

--- a/quickshow/main.cpp
+++ b/quickshow/main.cpp
@@ -38,6 +38,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
 		qDebug() << "Undefined argument:" << s;
 	}
 
+    // Uncaught exception is intentional here
 	if(!cli_opts.loadConfigFile())
 		return 1;
 

--- a/tools/qsqlmon/src/driver/qfhttpmysql/qfhttpmysql.h
+++ b/tools/qsqlmon/src/driver/qfhttpmysql/qfhttpmysql.h
@@ -30,8 +30,8 @@ class QNetworkReply;
 class QFHttpMySqlDriverHttp : public QObject
 {
 	Q_OBJECT
-	QF_FIELD_RW(QString, h, setH, ost)
-	QF_FIELD_RW(int, p, setP, ort)
+//	QF_FIELD_RW(QString, h, setH, ost)
+//	QF_FIELD_RW(int, p, setP, ort)
 	protected:
 		QNetworkAccessManager *f_http;
 		//QEventLoop *f_eventLoop;

--- a/tools/qsqlmon/src/sqldock.h
+++ b/tools/qsqlmon/src/sqldock.h
@@ -15,8 +15,6 @@ class SqlDock : public QDockWidget
 public:
 	SqlDock(QWidget *parent = 0, Qt::WindowFlags flags = 0);
 
-	QMenu *menu;
-
 public:
 	SqlTextEdit* sqlTextEdit();
 public:


### PR DESCRIPTION
Coverity has identified several instances of coding errors in QuickEvent code.  The most serious were uninitialized class members.  This patch set contains both plain fixes and code cleanup.  Please review.

https://scan.coverity.com/projects/quickbox