### PR TITLE
Fix logging into application window (issue #233)

### DIFF
--- a/quickevent/app/src/tablemodellogdevice.cpp
+++ b/quickevent/app/src/tablemodellogdevice.cpp
@@ -5,7 +5,7 @@
 TableModelLogDevice::TableModelLogDevice(QObject *parent)
  : Super(parent)
 {
-	m_logFilter.categoriesTresholds[QString()] = qf::core::Log::Level::Info;
+	m_logFilter.categoriesTresholds[QString("default")] = qf::core::Log::Level::Info;
 	m_logTableModel = new qf::core::model::LogTableModel(this);
 	QObject::connect(this, &qf::core::SignalLogDevice::logEntry, m_logTableModel, &qf::core::model::LogTableModel::addLogEntry);
 }


### PR DESCRIPTION
Commit 082a6a21cf4c changed the default category name.  The same name must be
known to the application log window.