### PR TITLE
Printing tickets on character printers connected to network.

### DIFF
--- a/quickevent/app/plugins/qml/Receipts/src/receiptsprinter.cpp
+++ b/quickevent/app/plugins/qml/Receipts/src/receiptsprinter.cpp
@@ -11,6 +11,7 @@
 #include <QDomDocument>
 #include <QPrinter>
 #include <QPrinterInfo>
+#include <QTcpSocket>
 
 //#define QF_TIMESCOPE_ENABLED
 #include <qf/core/utils/fileutils.h>
@@ -110,17 +111,51 @@ void ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVaria
 				qfError() << "Cannot open file" << f.fileName() << "for writing!";
 			}
 		};
-		if(!printer_opts.characterPrinterDirectory().isEmpty()) {
-			QString fn = printer_opts.characterPrinterDirectory();
-			qf::core::utils::FileUtils::ensurePath(fn);
-			QCryptographicHash ch(QCryptographicHash::Sha1);
-			for(QByteArray ba : data_lines)
-				ch.addData(ba);
-			fn += '/' + QString::fromLatin1(ch.result().toHex().mid(0, 8)) + ".txt";
-			save_file(fn);
-		}
-		else if (!printer_opts.characterPrinterDevice().isEmpty()) {
-			save_file(printer_opts.characterPrinterDevice());
+		switch(printer_opts.characterPrinterType()) {
+			case ReceiptsPrinterOptions::CharacterPrinteType::Directory: {
+				if(!printer_opts.characterPrinterDirectory().isEmpty()) {
+					QString fn = printer_opts.characterPrinterDirectory();
+					qf::core::utils::FileUtils::ensurePath(fn);
+					QCryptographicHash ch(QCryptographicHash::Sha1);
+					for(QByteArray ba : data_lines)
+						ch.addData(ba);
+					fn += '/' + QString::fromLatin1(ch.result().toHex().mid(0, 8)) + ".txt";
+					save_file(fn);
+				}
+				break;
+			}
+			case ReceiptsPrinterOptions::CharacterPrinteType::LPT: {
+				if (!printer_opts.characterPrinterDevice().isEmpty()) {
+					save_file(printer_opts.characterPrinterDevice());
+				}
+				break;
+			}
+			case ReceiptsPrinterOptions::CharacterPrinteType::Network: {
+				if (!printer_opts.characterPrinterAddress().isEmpty()) {
+					QTcpSocket socket;
+					socket.connectToHost(
+							printer_opts.characterPrinterAddress(),
+							9100,
+							QIODevice::WriteOnly);
+					if (socket.waitForConnected(1000)) {
+						for(const QByteArray& line : data_lines) {
+							socket.write(line);
+							socket.write("\n");
+						}
+						socket.disconnectFromHost();
+						if (!socket.waitForDisconnected(1000)) { // waiting till all data are sent
+							qfError() << "Error while closing the connection to printer: "
+									<< socket.error();
+						}
+					}
+					else {
+						qfError() << "Cannot open tcp connection to "
+								<< printer_opts.characterPrinterAddress()
+								<< " reason: " << socket.error();
+					}
+				}
+				break;
+			}
 		}
 	}
 }

--- a/quickevent/app/plugins/qml/Receipts/src/receiptsprinter.cpp
+++ b/quickevent/app/plugins/qml/Receipts/src/receiptsprinter.cpp
@@ -133,9 +133,13 @@ void ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVaria
 			case ReceiptsPrinterOptions::CharacterPrinteType::Network: {
 				if (!printer_opts.characterPrinterAddress().isEmpty()) {
 					QTcpSocket socket;
+					QString host = printer_opts.characterPrinterAddress().section(':', 0, 0);
+					int port = printer_opts.characterPrinterAddress().section(':', 1, 1).toInt();
+					if(port == 0)
+					    port = 9100;
 					socket.connectToHost(
-							printer_opts.characterPrinterAddress(),
-							9100,
+							host,
+							port,
 							QIODevice::WriteOnly);
 					if (socket.waitForConnected(1000)) {
 						for(const QByteArray& line : data_lines) {
@@ -149,8 +153,8 @@ void ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVaria
 						}
 					}
 					else {
-						qfError() << "Cannot open tcp connection to "
-								<< printer_opts.characterPrinterAddress()
+						qfError() << "Cannot open tcp connection to address "
+								<< host << " on port " << port
 								<< " reason: " << socket.error();
 					}
 				}

--- a/quickevent/app/plugins/qml/Receipts/src/receiptsprinteroptions.cpp
+++ b/quickevent/app/plugins/qml/Receipts/src/receiptsprinteroptions.cpp
@@ -17,7 +17,18 @@ QString ReceiptsPrinterOptions::printerCaption() const
 		ret = tr("Graphics") + ' ' + graphicsPrinterName();
 	}
 	else {
-		ret = tr("Character") + ' ' + characterPrinterModel() + " " + characterPrinterDevice();
+		ret = tr("Character") + ' ' + characterPrinterModel() + ' ';
+		switch(characterPrinterType()) {
+			case CharacterPrinteType::LPT:
+				ret +=  characterPrinterDevice();
+				break;
+			case CharacterPrinteType::Directory:
+				ret += characterPrinterDirectory();
+				break;
+			case CharacterPrinteType::Network:
+				ret += characterPrinterAddress();
+				break;
+		}
 	}
 	return ret;
 }

--- a/quickevent/app/plugins/qml/Receipts/src/receiptsprinteroptions.h
+++ b/quickevent/app/plugins/qml/Receipts/src/receiptsprinteroptions.h
@@ -22,7 +22,7 @@ class ReceiptsPrinterOptions : public QVariantMap
 public:
 	enum class PrinterType : int {GraphicPrinter = 0, CharacterPrinter};
 	enum CharacterPrinteType {
-		LPT = 0,
+		LPT,
 		Directory,
 		Network,
 	};

--- a/quickevent/app/plugins/qml/Receipts/src/receiptsprinteroptions.h
+++ b/quickevent/app/plugins/qml/Receipts/src/receiptsprinteroptions.h
@@ -21,7 +21,7 @@ class ReceiptsPrinterOptions : public QVariantMap
 	QF_VARIANTMAP_FIELD(QString, c, setC, haracterPrinterAddress)
 public:
 	enum class PrinterType : int {GraphicPrinter = 0, CharacterPrinter};
-	enum CharacterPrinteType {
+	enum class CharacterPrinteType {
 		LPT,
 		Directory,
 		Network,

--- a/quickevent/app/plugins/qml/Receipts/src/receiptsprinteroptions.h
+++ b/quickevent/app/plugins/qml/Receipts/src/receiptsprinteroptions.h
@@ -17,8 +17,15 @@ class ReceiptsPrinterOptions : public QVariantMap
 	QF_VARIANTMAP_FIELD2(QString, c, setC, haracterPrinterModel, QStringLiteral("Epson TM-T88V"))
 	QF_VARIANTMAP_FIELD2(int, c, setC, haracterPrinterLineLength, 41)
 	QF_VARIANTMAP_FIELD2(bool, is, set, CharacterPrinterGenerateControlCodes, true)
+	QF_VARIANTMAP_FIELD(int, c, setC, haracterPrinterType)
+	QF_VARIANTMAP_FIELD(QString, c, setC, haracterPrinterAddress)
 public:
 	enum class PrinterType : int {GraphicPrinter = 0, CharacterPrinter};
+	enum CharacterPrinteType {
+		LPT = 0,
+		Directory,
+		Network,
+	};
 public:
 	explicit ReceiptsPrinterOptions(const QVariantMap &o = QVariantMap());
 

--- a/quickevent/app/plugins/qml/Receipts/src/receiptsprinteroptionsdialog.cpp
+++ b/quickevent/app/plugins/qml/Receipts/src/receiptsprinteroptionsdialog.cpp
@@ -18,6 +18,23 @@ ReceiptsPrinterOptionsDialog::ReceiptsPrinterOptionsDialog(QWidget *parent) :
 		if(checked)
 			this->ui->stackedWidget->setCurrentIndex(1);
 	});
+	connect(ui->btCharacterPrinterLPT, &QPushButton::toggled, ui->cbxCharacterPrinterDevice, &QWidget::setEnabled);
+	connect(ui->btCharacterPrinterDirectory, &QPushButton::toggled, ui->edCharacterPrinterDirectory, &QWidget::setEnabled);
+	connect(ui->btCharacterPrinterNetwork, &QPushButton::toggled, ui->edCharacterPrinterAddress, &QWidget::setEnabled);
+	connect(
+		ui->cbxCharacterPrinterModel,
+		static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+		[this](int index) {
+		switch(index) {
+			case 0:
+				ui->edCharacterPrinterLineLength->setValue(41);
+				break;
+			case 1:
+				ui->edCharacterPrinterLineLength->setValue(40);
+				break;
+		}
+	});
+
 	loadPrinters();
 }
 
@@ -46,6 +63,18 @@ void ReceiptsPrinterOptionsDialog::setPrinterOptions(const ReceiptsPrinterOption
 		ui->cbxCharacterPrinterModel->setCurrentText(opts.characterPrinterModel());
 		ui->edCharacterPrinterLineLength->setValue(opts.characterPrinterLineLength());
 		ui->chkCharacterPrinterGenerateControlCodes->setChecked(opts.isCharacterPrinterGenerateControlCodes());
+		ui->edCharacterPrinterAddress->setText(opts.characterPrinterAddress());
+		switch(opts.characterPrinterType()) {
+			case ReceiptsPrinterOptions::CharacterPrinteType::LPT:
+				ui->btCharacterPrinterLPT->setChecked(true);
+				break;
+			case ReceiptsPrinterOptions::CharacterPrinteType::Directory:
+				ui->btCharacterPrinterDirectory->setChecked(true);
+				break;
+			case ReceiptsPrinterOptions::CharacterPrinteType::Network:
+				ui->btCharacterPrinterNetwork->setChecked(true);
+				break;
+		}
 	}
 }
 
@@ -63,6 +92,16 @@ ReceiptsPrinterOptions ReceiptsPrinterOptionsDialog::printerOptions()
 		ret.setCharacterPrinterModel(ui->cbxCharacterPrinterModel->currentText());
 		ret.setCharacterPrinterLineLength(ui->edCharacterPrinterLineLength->value());
 		ret.setCharacterPrinterGenerateControlCodes(ui->chkCharacterPrinterGenerateControlCodes->isChecked());
+		ret.setCharacterPrinterAddress(ui->edCharacterPrinterAddress->text());
+		if(ui->btCharacterPrinterLPT->isChecked()) {
+			ret.setCharacterPrinterType(ReceiptsPrinterOptions::CharacterPrinteType::LPT);
+		}
+		else if(ui->btCharacterPrinterDirectory->isChecked()) {
+			ret.setCharacterPrinterType(ReceiptsPrinterOptions::CharacterPrinteType::Directory);
+		}
+		else {
+			ret.setCharacterPrinterType(ReceiptsPrinterOptions::CharacterPrinteType::Network);
+		}
 	}
 	return ret;
 }

--- a/quickevent/app/plugins/qml/Receipts/src/receiptsprinteroptionsdialog.ui
+++ b/quickevent/app/plugins/qml/Receipts/src/receiptsprinteroptionsdialog.ui
@@ -6,12 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>418</width>
-    <height>300</height>
+    <width>478</width>
+    <height>359</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
+  </property>
+  <property name="layoutDirection">
+   <enum>Qt::LeftToRight</enum>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -45,6 +48,9 @@
    </item>
    <item>
     <widget class="QStackedWidget" name="stackedWidget">
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
@@ -56,17 +62,26 @@
       </layout>
      </widget>
      <widget class="QWidget" name="pgCharacterPrinter">
-      <layout class="QFormLayout" name="formLayout">
+      <layout class="QFormLayout" name="formLayout_4">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::ExpandingFieldsGrow</enum>
+       </property>
+       <property name="labelAlignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+       <property name="formAlignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
        <item row="0" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+        <widget class="QRadioButton" name="btCharacterPrinterLPT">
+         <property name="enabled">
+          <bool>true</bool>
          </property>
          <property name="text">
-          <string>Device</string>
+          <string>LPT device</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -105,29 +120,35 @@
          </item>
         </widget>
        </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
+       <item row="1" column="0">
+        <widget class="QRadioButton" name="btCharacterPrinterDirectory">
          <property name="text">
-          <string>Printer</string>
+          <string>Directory</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLineEdit" name="edCharacterPrinterDirectory">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QRadioButton" name="btCharacterPrinterNetwork">
+         <property name="text">
+          <string>Network address</string>
          </property>
         </widget>
        </item>
        <item row="2" column="1">
-        <widget class="QComboBox" name="cbxCharacterPrinterModel">
-         <item>
-          <property name="text">
-           <string>Epson TM-T88V</string>
-          </property>
-         </item>
+        <widget class="QLineEdit" name="edCharacterPrinterAddress">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -140,7 +161,7 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="9" column="1">
         <widget class="QSpinBox" name="edCharacterPrinterLineLength">
          <property name="suffix">
           <string> characters</string>
@@ -153,8 +174,15 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_4">
+       <item row="7" column="0" colspan="2">
+        <widget class="QCheckBox" name="chkCharacterPrinterGenerateControlCodes">
+         <property name="text">
+          <string>Generate printer control codes (escape sequences)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_3">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -162,18 +190,22 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Directory</string>
+          <string>Printer</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="QLineEdit" name="edCharacterPrinterDirectory"/>
-       </item>
-       <item row="3" column="0" colspan="2">
-        <widget class="QCheckBox" name="chkCharacterPrinterGenerateControlCodes">
-         <property name="text">
-          <string>Generate printer control codes (escape sequences)</string>
-         </property>
+       <item row="6" column="1">
+        <widget class="QComboBox" name="cbxCharacterPrinterModel">
+         <item>
+          <property name="text">
+           <string>Epson TM-T88V</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Epson TM-U220B</string>
+          </property>
+         </item>
         </widget>
        </item>
       </layout>
@@ -206,9 +238,6 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>cbxCharacterPrinterDevice</tabstop>
-  <tabstop>edCharacterPrinterDirectory</tabstop>
-  <tabstop>cbxCharacterPrinterModel</tabstop>
   <tabstop>edCharacterPrinterLineLength</tabstop>
   <tabstop>cbxGraphicPrinter</tabstop>
   <tabstop>btGraphicsPrinter</tabstop>


### PR DESCRIPTION
I've added possibility to print tickets on Epson character printers that are connected to network instead of LPT. This was pretty easy, because data format accepted by Epson printers on TCP port 9100 is the same as on LPT. 

I've also added Epson TM-U220B to the models combo box on printer options dialog and made it change the line length to 40 characters when selected.