### PR TITLE
Fixed crash on reloading invalid row in rowExternallySaved()

### DIFF
--- a/libqf/libqfqmlwidgets/src/tableview.cpp
+++ b/libqf/libqfqmlwidgets/src/tableview.cpp
@@ -1034,7 +1034,7 @@ void TableView::rowExternallySaved(const QVariant &id, int mode)
 				tmd->setValue(ri, idColumnName(), id);
 				tmd->setDirty(ri, idColumnName(), false);
 			}
-			if(ri >= 0) {
+			if(ri >= 0 && ri < tmd->rowCount()) {
 				if(mode == ModeEdit || mode == ModeView) {
 					int reloaded_row_cnt = tmd->reloadRow(ri);
 					if(reloaded_row_cnt != 1) {


### PR DESCRIPTION
This missing condition lead to reloading invalid row, when rowExternallySaved(id, mode) is called with id which doesn't exist in the table and there is no line selected in the table.

I came to this situation when trying to register new competitor using Card reader. After reading a card Edit Competitor dialog appeared, clicking on E1 button then caused a crash. 