### PR TITLE
fixing minQtVersion to 5.3.1

### DIFF
--- a/quickbox.pro
+++ b/quickbox.pro
@@ -1,7 +1,7 @@
 include(utils.pri)
 
 #version check qt
-!minQtVersion(5, 2, 1) {
+!minQtVersion(5, 3, 1) {
 	message("Cannot build QuickBox with Qt version $${QT_VERSION}.")
 	error("Use at least Qt 5.3.1.")
 }


### PR DESCRIPTION
Z chyboveho hlaseni vyplyva, ze je treba Qt >= 5.3.1, ale automaticka podminka tomu neodpovidala.
Pritom proti Qt 5.3.0 mi to na linuxu skutecne prelozit neslo (nekompatibilita v typu qt::core::sql::DbEnumCache).
