### PR TITLE
Oprava nazvu disciplin z ORISu

### DIFF
--- a/quickevent/app/plugins/qml/Event/src/eventdialogwidget.ui
+++ b/quickevent/app/plugins/qml/Event/src/eventdialogwidget.ui
@@ -254,12 +254,12 @@
     <widget class="QComboBox" name="cbxDisciplineId">
      <item>
       <property name="text">
-       <string>Classic</string>
+       <string>Long distance</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Short distance</string>
+       <string>Middle distance</string>
       </property>
      </item>
      <item>
@@ -269,12 +269,17 @@
      </item>
      <item>
       <property name="text">
-       <string>Middle</string>
+       <string>Ultralong distance</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Relays</string>
+       <string>Relay</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Teams</string>
       </property>
      </item>
     </widget>


### PR DESCRIPTION
Anglicke nazvy disciplin jsou prejaty z pravidel IOF, pripadne vystupu ORISu,
ktery vedle ciselneho identifikatoru discipliny vraci i cesky a anglicky nazev.
Pridan identifikator pro druzstva. Z beznych disciplin zatim zustava nepokryty NOB s id 9.