### PR TITLE
fix #488 IOF XMLv3 import

### DIFF
--- a/quickevent/app/plugins/Classes/src/classeswidget.cpp
+++ b/quickevent/app/plugins/Classes/src/classeswidget.cpp
@@ -738,6 +738,8 @@ void ClassesWidget::import_ocad_iofxml_3()
 						else
 							qfError() << QString("Xml file format error: bad control code %1 in %2").arg(code).arg(dump_element(el_control));
 						*/
+						if(code_str.startsWith(quickevent::core::CodeDef::CONTROL_TYPE_START) || code_str.startsWith(quickevent::core::CodeDef::CONTROL_TYPE_FINISH))
+								continue;
 						codes << code_str;
 					}
 					coursedef.setCodes(codes);


### PR DESCRIPTION
import přidával do seznamu kódů jednotlivých tratí i start a cíl -> opraveno

ps: docela se mi líbí kontrola xml souboru pomocí řádků co jsou zakomentované nad tím, co jsem přidal. Je nějaký důvod, proč nejsou použity?