### PR TITLE
Startovní čísla u reportu kluby n etap, opraven checkbox "Exclude DISQ"

### DIFF
--- a/quickevent/app/plugins/Runs/qml/reports/startList_classes_nstages.qml
+++ b/quickevent/app/plugins/Runs/qml/reports/startList_classes_nstages.qml
@@ -155,7 +155,10 @@ Report {
 								visible: root.isPrintStartNumbers
 								width: 16
 								halign: Frame.AlignRight
-								textFn: runnersDetail.dataFn("startNumber");
+								textFn: function() {
+									var sn = runnersDetail.dataFn("startNumber")();
+									return sn > 0? sn: "";
+								}
 							}
 							Cell {
 								width: hdrRegistration.width

--- a/quickevent/app/plugins/Runs/qml/reports/startList_clubs.qml
+++ b/quickevent/app/plugins/Runs/qml/reports/startList_clubs.qml
@@ -105,7 +105,7 @@ Report {
 							layout: Frame.LayoutHorizontal
 							function dataFn(field_name) {return function() {return rowData(field_name);}}
 							Cell {
-								width: 12
+								width: 13
 								halign: Frame.AlignRight
 								textFn: function() { return OGTime.msecToString_mmss(runnersDetail.rowData("startTimeMs"));}
 							}

--- a/quickevent/app/plugins/Runs/qml/reports/startList_clubs_nstages.qml
+++ b/quickevent/app/plugins/Runs/qml/reports/startList_clubs_nstages.qml
@@ -110,6 +110,27 @@ Report {
 							textFn: detail.dataFn("name");
 							textStyle: myStyle.textStyleBold
 						}
+						Cell {
+							visible: root.isPrintStartNumbers
+							id: hdrStartNumber
+							width: 16
+							textStyle: myStyle.textStyleBold
+							halign: Frame.AlignRight
+							text: qsTr("Bib");
+						}
+						Cell {
+							id: hdrRegistration
+							width: 25
+							textStyle: myStyle.textStyleBold
+							text: qsTr("Registration");
+						}
+						Cell {
+							id: hdrSI
+							width: 18
+							textStyle: myStyle.textStyleBold
+							halign: Frame.AlignRight
+							text: qsTr("SI");
+						}
 						Component.onCompleted: {
 							//console.warn("============= root.stageCount:", root.stageCount)
 							for(var i=0; i<root.stagesCount; i++) {
@@ -134,25 +155,28 @@ Report {
 							layout: Frame.LayoutHorizontal
 							function dataFn(field_name) {return function() {return rowData(field_name);}}
 							Cell {
-								width: 20
+								width: 15
 								textFn: runnersDetail.dataFn("classes.name");
 							}
 							Cell {
 								width: "%"
 								textFn: runnersDetail.dataFn("competitorName");
 							}
-							Para {
+							Cell {
 								visible: root.isPrintStartNumbers
-								width: 16
+								width: hdrStartNumber.width
 								halign: Frame.AlignRight
-								textFn: runnersDetail.dataFn("startNumber");
+								textFn: function() {
+									var sn = runnersDetail.dataFn("startNumber")();
+									return sn > 0? sn: "";
+								}
 							}
 							Cell {
-								width: 25
+								width: hdrRegistration.width
 								textFn: runnersDetail.dataFn("registration");
 							}
 							Cell {
-								width: 18
+								width: hdrSI.width
 								halign: Frame.AlignRight
 								textFn: runnersDetail.dataFn("competitors.siId");
 							}

--- a/quickevent/app/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/plugins/Runs/src/runsplugin.cpp
@@ -1433,8 +1433,8 @@ void RunsPlugin::report_startListClubsNStages()
 	dlg.loadPersistentSettings();
 
 	dlg.setStagesCount(event_plugin->stageCount());
-	dlg.setStartListOptionsVisible(false);
-	//dlg.setVacantsVisible(false);
+	dlg.setStartListOptionsVisible(true);
+	dlg.setVacantsVisible(false);
 	dlg.setStagesOptionVisible(true);
 	dlg.setClassFilterVisible(false);
 	dlg.setClassFilterVisible(true);

--- a/quickevent/app/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/plugins/Runs/src/runsplugin.cpp
@@ -1468,7 +1468,7 @@ void RunsPlugin::report_resultsClasses()
 	dlg.setResultOptionsVisible(true);
 	//dlg.setPageLayoutVisible(false);
 	if(dlg.exec()) {
-		auto tt = currentStageResultsTable(dlg.sqlWhereExpression(), dlg.resultNumPlaces());
+		auto tt = currentStageResultsTable(dlg.sqlWhereExpression(), dlg.resultNumPlaces(), dlg.options().isResultExcludeDisq());
 		auto opts = dlg.optionsMap();
 		QVariantMap props;
 		props["options"] = opts;
@@ -1492,7 +1492,7 @@ void RunsPlugin::report_resultsForSpeaker()
 	dlg.setResultOptionsVisible(true);
 	//dlg.setPageLayoutVisible(false);
 	if(dlg.exec()) {
-		auto tt = currentStageResultsTable(dlg.sqlWhereExpression(), dlg.resultNumPlaces());
+		auto tt = currentStageResultsTable(dlg.sqlWhereExpression(), dlg.resultNumPlaces(), dlg.options().isResultExcludeDisq());
 		auto opts = dlg.optionsMap();
 		QVariantMap props;
 		props["options"] = opts;


### PR DESCRIPTION
Přidal jsem ještě možnost tisknout startovní čísla v reportu kluby n etap (+ popisky sloupců).

Opravena funkčnost checkboxu "Exclude DISQ" u tisku výsledků aktuální etapy + aktuální etapy pro komentátora.

Souvisí s #113 a #511 