### PR TITLE
if there is only one "run", propagate widget SI card change

### DIFF
--- a/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
@@ -189,8 +189,8 @@ CompetitorWidget::CompetitorWidget(QWidget *parent) :
 	connect(ui->spinBox, qOverload<int>(&QSpinBox::valueChanged),[=](int newSiNumber) // spinbox= widget SI card edit box
 	{
 		if(eventPlugin()->stageCount() == 1 && m_runsModel->rowCount() == 1 ) {
-			m_runsModel->setValue(0, RunsModel::col_runs_siId, newSiNumber);
-			ui->tblRuns->reset();
+			m_runsModel->setValue(0, RunsModel::col_runs_siId, newSiNumber); // update SI in runs model
+			ui->tblRuns->reset(); // reload ui to see the change
 		}
 	});
 }

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
@@ -184,6 +184,14 @@ CompetitorWidget::CompetitorWidget(QWidget *parent) :
 			});
 		}
 	}
+
+	// if there is only one run propagate windget SI card change from competitors to runs
+	connect(ui->spinBox, qOverload<int>(&QSpinBox::valueChanged),[=](int newSiNumber) // spinbox= widget SI card edit box
+	{
+		if(eventPlugin()->stageCount() == 1 && m_runsModel->rowCount() == 1 ) {
+			m_runsModel->setValue(0, RunsModel::col_runs_siId, newSiNumber);
+		}
+	});
 }
 
 CompetitorWidget::~CompetitorWidget()

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
@@ -185,11 +185,11 @@ CompetitorWidget::CompetitorWidget(QWidget *parent) :
 		}
 	}
 
-	// if there is only one run propagate windget SI card change from competitors to runs
-	connect(ui->spinBox, qOverload<int>(&QSpinBox::valueChanged),[=](int newSiNumber) // spinbox= widget SI card edit box
+    // if there is only one run propagate widget SI card change from competitors to runs
+    connect(ui->edSiId, qOverload<int>(&QSpinBox::valueChanged),[=](int new_si_number) // widget SIcard edit box
 	{
 		if(eventPlugin()->stageCount() == 1 && m_runsModel->rowCount() == 1 ) {
-			m_runsModel->setValue(0, RunsModel::col_runs_siId, newSiNumber); // update SI in runs model
+            m_runsModel->setValue(0, RunsModel::col_runs_siId, new_si_number); // update SI in runs model
 			ui->tblRuns->reset(); // reload ui to see the change
 		}
 	});

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
@@ -185,11 +185,11 @@ CompetitorWidget::CompetitorWidget(QWidget *parent) :
 		}
 	}
 
-    // if there is only one run propagate widget SI card change from competitors to runs
-    connect(ui->edSiId, qOverload<int>(&QSpinBox::valueChanged),[=](int new_si_number) // widget SIcard edit box
+	// if there is only one run propagate widget SI card change from competitors to runs
+	connect(ui->edSiId, qOverload<int>(&QSpinBox::valueChanged),[=](int new_si_number) // widget SIcard edit box
 	{
 		if(eventPlugin()->stageCount() == 1 && m_runsModel->rowCount() == 1 ) {
-            m_runsModel->setValue(0, RunsModel::col_runs_siId, new_si_number); // update SI in runs model
+			m_runsModel->setValue(0, RunsModel::col_runs_siId, new_si_number); // update SI in runs model
 			ui->tblRuns->reset(); // reload ui to see the change
 		}
 	});

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
@@ -190,6 +190,7 @@ CompetitorWidget::CompetitorWidget(QWidget *parent) :
 	{
 		if(eventPlugin()->stageCount() == 1 && m_runsModel->rowCount() == 1 ) {
 			m_runsModel->setValue(0, RunsModel::col_runs_siId, newSiNumber);
+			ui->tblRuns->reset();
 		}
 	});
 }

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.ui
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.ui
@@ -81,12 +81,12 @@
          <string>&amp;SI</string>
         </property>
         <property name="buddy">
-         <cstring>spinBox</cstring>
+         <cstring>edSiId</cstring>
         </property>
        </widget>
       </item>
       <item row="1" column="4">
-       <widget class="quickevent::gui::si::SiIdEdit" name="spinBox">
+       <widget class="quickevent::gui::si::SiIdEdit" name="edSiId">
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
@@ -288,7 +288,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>cbxClass</tabstop>
-  <tabstop>spinBox</tabstop>
+  <tabstop>edSiId</tabstop>
   <tabstop>lineEdit_2</tabstop>
   <tabstop>lineEdit_3</tabstop>
   <tabstop>lineEdit_4</tabstop>


### PR DESCRIPTION
Pokud se nyní změní v dialogu pro edit závodníka čip, tak se nepřenastaví u jednotlivých rozběhů, což dává smysl u víceetapových závodů, u těch samostatných však ne.

=> pokud je jen jeden "run" tedy jednoetový závod, propagovat zmenu cipu i do runs