### PR TITLE
Fix direct receipt printing layout on Windows (overlapping text / blanks)

### DIFF
--- a/quickevent/app/quickevent/plugins/Receipts/src/receiptsprinter.cpp
+++ b/quickevent/app/quickevent/plugins/Receipts/src/receiptsprinter.cpp
@@ -50,6 +50,7 @@ bool ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVaria
 	ReceiptsSettings settings;
 	QPrinter *printer = nullptr;
 	QPaintDevice *paint_device = nullptr;
+	qff::MainWindow *fwk = qff::MainWindow::frameWork();
 	if(settings.printerTypeEnum() == ReceiptsSettings::PrinterType::GraphicPrinter) {
 		QF_TIME_SCOPE("init graphics printer");
 		QPrinterInfo pi = QPrinterInfo::printerInfo(settings.graphicsPrinterName());
@@ -72,10 +73,10 @@ bool ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVaria
 				 << ((settings.characterPrinterTypeEnum() == ReceiptsSettings::CharacterPrinteType::Directory)?
 						 settings.characterPrinterDirectory() :
 						 settings.characterPrinterDevice());
-		qff::MainWindow *fwk = qff::MainWindow::frameWork();
 		paint_device = fwk;
 	}
-	qf::gui::reports::ReportProcessor rp(paint_device);
+	// Use screen widget (stable DPI) for layout; QPrinter DPI can change after QPainter::begin() on Windows
+	qf::gui::reports::ReportProcessor rp(fwk);
 	{
 		QF_TIME_SCOPE("setting report and data");
 		auto *plugin = qf::gui::framework::getPlugin<Receipts::ReceiptsPlugin>();


### PR DESCRIPTION
## Bug
- `ReceiptsPrinter::printReceipt()` passed the `QPrinter` as paint device to
  `ReportProcessor` for report layout. On Windows, `QPrinter::logicalDpiX()`
  returns a different value before vs. after `QPainter::begin()` is called on
  it, causing a DPI mismatch between the layout phase (pre-begin) and the draw
  phase (post-begin). The result was overlapping text lines and large blank gaps
  in directly-printed receipts.
    * Work-around was using no scaling (100%) - #1012

Left image was generated by `Print Receipt` (bad), right one by `Show Receipt`.

<img width="1224" height="969" alt="image" src="https://github.com/user-attachments/assets/d8368f6d-554b-4f34-91da-cea089033df2" />

## Fix

- Fixed by using the main window (`QWidget`) as the `ReportProcessor` paint
  device, giving layout a stable screen DPI — exactly what `ReportViewWidget`
  does when rendering the receipt preview. `ReportPainter` still draws on the
  `QPrinter`; all stored `renderedRect` coordinates are in mm and are correctly
  converted to printer pixels at draw time.
  * This only affects the bad `Print Receipt` path.

Validation on Windows (Print Receipt to PDF Printer & to Epson TM-T70):
<img width="379" height="571" alt="image" src="https://github.com/user-attachments/assets/2e4256b9-8986-4aaf-b3db-1f8f2da4c7a9" />

## Credits 
Credits go to @casidlo for pointing me to the GH Issue and work-around; and to
Claude Code for the fix (which I verified locally on Windows 11).

I'm not experiencing the other scaling/blurry issues so can't confirm it fixes the full
issue.