### PR TITLE
Implement new DB changes API

### DIFF
--- a/libqf/libqfcore/CMakeLists.txt
+++ b/libqf/libqfcore/CMakeLists.txt
@@ -13,6 +13,8 @@ add_library(libqfcore SHARED
     src/sql/query.cpp
     src/sql/querybuilder.cpp
     src/sql/transaction.cpp
+	src/sql/recchng.h src/sql/recchng.cpp
+	src/sql/qxsql.h src/sql/qxsql.cpp
 
     src/utils/clioptions.cpp
     src/utils/crypt.cpp

--- a/libqf/libqfcore/CMakeLists.txt
+++ b/libqf/libqfcore/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(libqfcore SHARED
     src/sql/query.cpp
     src/sql/querybuilder.cpp
     src/sql/transaction.cpp
-	src/sql/recchng.h src/sql/recchng.cpp
+	src/sql/qxrecchng.h src/sql/qxrecchng.cpp
 	src/sql/qxsql.h src/sql/qxsql.cpp
 
     src/utils/clioptions.cpp

--- a/libqf/libqfcore/include/qf/core/sql/qxrecchng.h
+++ b/libqf/libqfcore/include/qf/core/sql/qxrecchng.h
@@ -1,0 +1,1 @@
+#include "../../../../src/sql/qxrecchng.h"

--- a/libqf/libqfcore/include/qf/core/sql/qxsql.h
+++ b/libqf/libqfcore/include/qf/core/sql/qxsql.h
@@ -1,0 +1,1 @@
+#include "../../../../src/sql/qxsql.h"

--- a/libqf/libqfcore/include/qf/core/sql/recchng.h
+++ b/libqf/libqfcore/include/qf/core/sql/recchng.h
@@ -1,1 +1,0 @@
-#include "../../../../src/sql/recchng.h"

--- a/libqf/libqfcore/include/qf/core/sql/recchng.h
+++ b/libqf/libqfcore/include/qf/core/sql/recchng.h
@@ -1,0 +1,1 @@
+#include "../../../../src/sql/recchng.h"

--- a/libqf/libqfcore/src/sql/qxrecchng.cpp
+++ b/libqf/libqfcore/src/sql/qxrecchng.cpp
@@ -1,4 +1,4 @@
-#include "recchng.h"
+#include "qxrecchng.h"
 
 #include "../core/log.h"
 
@@ -13,7 +13,7 @@ RecOp recopFromString(const QString &s)
 	return RecOp::Update;
 }
 }
-QVariantMap RecChng::toVariantMap() const
+QVariantMap QxRecChng::toVariantMap() const
 {
 	QVariantMap ret;
 	ret["table"] = table;
@@ -28,9 +28,10 @@ QVariantMap RecChng::toVariantMap() const
 	return ret;
 }
 
-RecChng RecChng::fromVariantMap(const QVariantMap &m)
+QxRecChng QxRecChng::fromVariantMap(const QVariantMap &m)
 {
-	RecChng ret;
+	QxRecChng ret;
+	ret.table = m.value("table").toString();
 	ret.op = recopFromString(m.value("op").toString());
 	ret.id = m.value("id").value<qint64>();
 	if (ret.op != RecOp::Delete) {
@@ -40,7 +41,7 @@ RecChng RecChng::fromVariantMap(const QVariantMap &m)
 	return ret;
 }
 
-QString RecChng::recopToString(RecOp op)
+QString QxRecChng::recopToString(RecOp op)
 {
 	switch (op) {
 	case RecOp::Insert: return "Insert";

--- a/libqf/libqfcore/src/sql/qxrecchng.h
+++ b/libqf/libqfcore/src/sql/qxrecchng.h
@@ -13,7 +13,8 @@ enum class RecOp {
 	Delete,
 };
 
-struct QFCORE_DECL_EXPORT RecChng {
+struct QFCORE_DECL_EXPORT QxRecChng
+{
 	QString table;
 	qint64 id = 0;
 	QVariantMap record;
@@ -21,7 +22,7 @@ struct QFCORE_DECL_EXPORT RecChng {
 	QString issuer;
 
 	QVariantMap toVariantMap() const;
-	static RecChng fromVariantMap(const QVariantMap &m);
+	static QxRecChng fromVariantMap(const QVariantMap &m);
 	static QString recopToString(RecOp op);
 };
 }

--- a/libqf/libqfcore/src/sql/qxsql.cpp
+++ b/libqf/libqfcore/src/sql/qxsql.cpp
@@ -1,0 +1,188 @@
+#include "qxsql.h"
+
+#include <QSqlQuery>
+#include <QSqlError>
+#include <QSqlRecord>
+
+namespace qf::core::sql {
+
+//================================================================
+// QxSqlApi
+//================================================================
+qint64 QxSqlApi::createRecord(const QString &table, const Record &record)
+{
+	QStringList keys;
+	QStringList vals;
+
+	for (auto it = record.begin(); it != record.end(); ++it) {
+		keys << it.key();
+		vals << (":" + it.key());
+	}
+
+	QString qs = QString("INSERT INTO %1 (%2) VALUES (%3) RETURNING id")
+			.arg(table, keys.join(", "), vals.join(", "));
+
+	QueryResult result = query(qs, record);
+
+	if (result.rows.isEmpty() || result.rows[0].isEmpty()) {
+		throw std::runtime_error("Insert should return an ID");
+	}
+
+	bool ok = false;
+	qint64 id = result.rows[0][0].toLongLong(&ok);
+
+	if (!ok) {
+		throw std::runtime_error("Insert should return an integer ID");
+	}
+
+	return id;
+}
+
+std::optional<Record> QxSqlApi::readRecord(const QString &table, qint64 id, const std::optional<QStringList> &fields)
+{
+	auto records = listOneOrMoreRecords(table, fields, id, 1);
+	if (!records.isEmpty()) {
+		return records.first();
+	}
+	return std::nullopt;
+}
+
+bool QxSqlApi::updateRecord(const QString &table, qint64 id, const Record &record)
+{
+	QStringList keyVals;
+
+	for (auto it = record.begin(); it != record.end(); ++it) {
+		keyVals << QString("%1 = :%1").arg(it.key());
+	}
+
+	QString qs = QString("UPDATE %1 SET %2 WHERE id = %3")
+			.arg(table, keyVals.join(", "), QString::number(id));
+
+	ExecResult res = exec(qs, record);
+	return res.rowsAffected == 1;
+}
+
+bool QxSqlApi::deleteRecord(const QString &table, qint64 id)
+{
+	QString qs =
+			QString("DELETE FROM %1 WHERE id = %2").arg(table, QString::number(id));
+
+	ExecResult res = exec(qs, {});
+	return res.rowsAffected == 1;
+}
+
+QList<Record> QxSqlApi::listOneOrMoreRecords(const QString &table, const std::optional<QStringList> &fields, const std::optional<qint64> &id, const std::optional<qint64> &limit)
+{
+	QString fieldsStr =
+			(fields && !fields->isEmpty()) ? fields->join(", ") : "*";
+
+	QString qs = QString("SELECT %1 FROM %2").arg(fieldsStr, table);
+
+	if (id.has_value()) {
+		qs += QString(" WHERE id >= %1").arg(*id);
+	}
+
+	if (limit.has_value()) {
+		qs += QString(" LIMIT %1").arg(*limit);
+	}
+
+	QueryResult result = query(qs, {});
+
+	QList<Record> records;
+	records.reserve(result.rows.size()); // still valid for QList (Qt 6)
+
+	for (int i = 0; i < result.rows.size(); ++i) {
+		auto rec = result.record(i);
+		if (rec.has_value()) {
+			records.append(*rec);
+		}
+	}
+
+	return records;
+}
+
+//================================================================
+// QxSql
+//================================================================
+QxSql::QxSql(const QSqlDatabase &db)
+	: m_db(db)
+{
+
+}
+
+QueryResult QxSql::query(const QString &query, const QVariantMap &params)
+{
+	QSqlQuery q(m_db);
+	q.prepare(query);
+	for (const auto &[key, val] : params.asKeyValueRange()) {
+		q.bindValue(QStringLiteral(":%1").arg(key), val);
+	}
+	if (!q.exec()) {
+		throw std::runtime_error(q.lastError().text().toStdString());
+	}
+	QueryResult result;
+	for (int i = 0; i < q.record().count(); ++i) {
+		result.columns.append(q.record().fieldName(i).toLower());
+	}
+	while (q.next()) {
+		QList<QVariant> row;
+		for (int i = 0; i < q.record().count(); ++i) {
+			row.append(q.value(i));
+		}
+		result.rows.insert(result.rows.size(), row);
+	}
+	return result;
+}
+
+ExecResult QxSql::exec(const QString &query, const QVariantMap &params)
+{
+	QSqlQuery q(m_db);
+	q.prepare(query);
+	for (const auto &[key, val] : params.asKeyValueRange()) {
+		q.bindValue(QStringLiteral(":%1").arg(key), val);
+	}
+	if (!q.exec()) {
+		throw std::runtime_error(q.lastError().text().toStdString());
+	}
+	ExecResult result;
+	result.rowsAffected = q.numRowsAffected();
+	return result;
+}
+
+qint64 QxSql::createRecord(const QString &table, const Record &record)
+{
+	auto id = QxSqlApi::createRecord(table, record);
+	emit dbRecChng(qf::core::sql::RecChng{.table = table,
+										  .id = id,
+										  .record = record,
+										  .op = qf::core::sql::RecOp::Insert,
+										  .issuer = {}});
+	return id;
+}
+
+bool QxSql::updateRecord(const QString &table, qint64 id, const Record &record)
+{
+	auto ok = QxSqlApi::updateRecord(table, id, record);
+	if (ok) {
+		emit dbRecChng(qf::core::sql::RecChng{.table = table,
+											  .id = id,
+											  .record = record,
+											  .op = qf::core::sql::RecOp::Update,
+											  .issuer = {}});
+	}
+	return ok;
+}
+
+bool QxSql::deleteRecord(const QString &table, qint64 id)
+{
+	auto ok = QxSqlApi::deleteRecord(table, id);
+	if (ok) {
+		emit dbRecChng(qf::core::sql::RecChng{.table = table,
+											  .id = id,
+											  .record = {},
+											  .op = qf::core::sql::RecOp::Delete,
+											  .issuer = {}});
+	}
+	return ok;
+}
+}

--- a/libqf/libqfcore/src/sql/qxsql.cpp
+++ b/libqf/libqfcore/src/sql/qxsql.cpp
@@ -11,8 +11,9 @@ namespace qf::core::sql {
 //================================================================
 // QxSqlApi
 //================================================================
-qint64 QxSqlApi::createRecord(const QString &table, const Record &record)
+qint64 QxSqlApi::createRecord(const QString &table, const Record &record, const QString &issuer)
 {
+	Q_UNUSED(issuer)
 	QStringList keys;
 	QStringList vals;
 
@@ -49,8 +50,9 @@ std::optional<Record> QxSqlApi::readRecord(const QString &table, qint64 id, cons
 	return std::nullopt;
 }
 
-bool QxSqlApi::updateRecord(const QString &table, qint64 id, const Record &record)
+bool QxSqlApi::updateRecord(const QString &table, qint64 id, const Record &record, const QString &issuer)
 {
+	Q_UNUSED(issuer)
 	QStringList keyVals;
 
 	for (auto it = record.begin(); it != record.end(); ++it) {
@@ -64,10 +66,10 @@ bool QxSqlApi::updateRecord(const QString &table, qint64 id, const Record &recor
 	return res.rowsAffected == 1;
 }
 
-bool QxSqlApi::deleteRecord(const QString &table, qint64 id)
+bool QxSqlApi::deleteRecord(const QString &table, qint64 id, const QString &issuer)
 {
-	QString qs =
-			QString("DELETE FROM %1 WHERE id = %2").arg(table, QString::number(id));
+	Q_UNUSED(issuer)
+	QString qs = QString("DELETE FROM %1 WHERE id = %2").arg(table, QString::number(id));
 
 	ExecResult res = exec(qs, {});
 	return res.rowsAffected == 1;
@@ -151,39 +153,39 @@ ExecResult QxSql::exec(const QString &query, const QVariantMap &params)
 	return result;
 }
 
-qint64 QxSql::createRecord(const QString &table, const Record &record)
+qint64 QxSql::createRecord(const QString &table, const Record &record, const QString &issuer)
 {
-	auto id = QxSqlApi::createRecord(table, record);
-	emit dbRecChng(qf::core::sql::RecChng{.table = table,
+	auto id = QxSqlApi::createRecord(table, record, issuer);
+	emit dbRecChng(qf::core::sql::QxRecChng{.table = table,
 										  .id = id,
 										  .record = record,
 										  .op = qf::core::sql::RecOp::Insert,
-										  .issuer = {}});
+										  .issuer = issuer});
 	return id;
 }
 
-bool QxSql::updateRecord(const QString &table, qint64 id, const Record &record)
+bool QxSql::updateRecord(const QString &table, qint64 id, const Record &record, const QString &issuer)
 {
-	auto ok = QxSqlApi::updateRecord(table, id, record);
+	auto ok = QxSqlApi::updateRecord(table, id, record, issuer);
 	if (ok) {
-		emit dbRecChng(qf::core::sql::RecChng{.table = table,
+		emit dbRecChng(qf::core::sql::QxRecChng{.table = table,
 											  .id = id,
 											  .record = record,
 											  .op = qf::core::sql::RecOp::Update,
-											  .issuer = {}});
+											  .issuer = issuer});
 	}
 	return ok;
 }
 
-bool QxSql::deleteRecord(const QString &table, qint64 id)
+bool QxSql::deleteRecord(const QString &table, qint64 id, const QString &issuer)
 {
-	auto ok = QxSqlApi::deleteRecord(table, id);
+	auto ok = QxSqlApi::deleteRecord(table, id, issuer);
 	if (ok) {
-		emit dbRecChng(qf::core::sql::RecChng{.table = table,
+		emit dbRecChng(qf::core::sql::QxRecChng{.table = table,
 											  .id = id,
 											  .record = {},
 											  .op = qf::core::sql::RecOp::Delete,
-											  .issuer = {}});
+											  .issuer = issuer});
 	}
 	return ok;
 }

--- a/libqf/libqfcore/src/sql/qxsql.cpp
+++ b/libqf/libqfcore/src/sql/qxsql.cpp
@@ -1,5 +1,7 @@
 #include "qxsql.h"
 
+#include <qf/core/exception.h>
+
 #include <QSqlQuery>
 #include <QSqlError>
 #include <QSqlRecord>
@@ -25,14 +27,14 @@ qint64 QxSqlApi::createRecord(const QString &table, const Record &record)
 	QueryResult result = query(qs, record);
 
 	if (result.rows.isEmpty() || result.rows[0].isEmpty()) {
-		throw std::runtime_error("Insert should return an ID");
+		throw qf::core::Exception("Insert should return an ID");
 	}
 
 	bool ok = false;
 	qint64 id = result.rows[0][0].toLongLong(&ok);
 
 	if (!ok) {
-		throw std::runtime_error("Insert should return an integer ID");
+		throw qf::core::Exception("Insert should return an integer ID");
 	}
 
 	return id;
@@ -118,7 +120,7 @@ QueryResult QxSql::query(const QString &query, const QVariantMap &params)
 		q.bindValue(QStringLiteral(":%1").arg(key), val);
 	}
 	if (!q.exec()) {
-		throw std::runtime_error(q.lastError().text().toStdString());
+		throw qf::core::Exception(q.lastError().text());
 	}
 	QueryResult result;
 	for (int i = 0; i < q.record().count(); ++i) {
@@ -142,7 +144,7 @@ ExecResult QxSql::exec(const QString &query, const QVariantMap &params)
 		q.bindValue(QStringLiteral(":%1").arg(key), val);
 	}
 	if (!q.exec()) {
-		throw std::runtime_error(q.lastError().text().toStdString());
+		throw qf::core::Exception(q.lastError().text());
 	}
 	ExecResult result;
 	result.rowsAffected = q.numRowsAffected();

--- a/libqf/libqfcore/src/sql/qxsql.h
+++ b/libqf/libqfcore/src/sql/qxsql.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "recchng.h"
+
+#include <QList>
+#include <QMap>
+#include <QString>
+#include <QStringList>
+#include <QVariant>
+#include <QSqlDatabase>
+
+#include <optional>
+
+namespace qf::core::sql {
+
+using Record = QVariantMap;
+
+struct QFCORE_DECL_EXPORT QueryResult
+{
+	QStringList columns;
+	QList<QList<QVariant>> rows;
+
+	std::optional<Record> record(int i) const
+	{
+		if (i < 0 || i >= rows.size()) {
+			return std::nullopt;
+		}
+		Record r;
+		const auto &row = rows[i];
+		for (int j = 0; j < columns.size(); ++j) {
+			r[columns[j]] = row.value(j);
+		}
+		return r;
+	}
+};
+
+struct QFCORE_DECL_EXPORT ExecResult
+{
+	qint64 rowsAffected = 0;
+};
+
+class QFCORE_DECL_EXPORT QxSqlApi
+{
+public:
+	virtual ~QxSqlApi() = default;
+	virtual QueryResult query(const QString &query, const QVariantMap &params) = 0;
+	virtual ExecResult exec(const QString &query, const QVariantMap &params) = 0;
+
+	QList<Record> listRecords(
+			const QString &table,
+			const std::optional<QStringList> &fields = std::nullopt,
+			const std::optional<qint64> &fromId = std::nullopt,
+			const std::optional<qint64> &limit = std::nullopt)
+	{
+		return listOneOrMoreRecords(table, fields, fromId, limit);
+	}
+
+	virtual qint64 createRecord(const QString &table, const Record &record);
+	virtual std::optional<Record> readRecord(const QString &table, qint64 id, const std::optional<QStringList> &fields = std::nullopt);
+	virtual bool updateRecord(const QString &table, qint64 id, const Record &record);
+	virtual bool deleteRecord(const QString &table, qint64 id);
+protected:
+	QList<Record> listOneOrMoreRecords(
+			const QString &table,
+			const std::optional<QStringList> &fields,
+			const std::optional<qint64> &id,
+			const std::optional<qint64> &limit);
+};
+
+class QFCORE_DECL_EXPORT QxSql : public QObject, public QxSqlApi
+{
+	Q_OBJECT
+public:
+	QxSql(const QSqlDatabase &db = QSqlDatabase());
+	~QxSql() override = default;
+
+	Q_SIGNAL void dbRecChng(const qf::core::sql::RecChng &recchng);
+
+	QueryResult query(const QString &query, const QVariantMap &params) override;
+	ExecResult exec(const QString &query, const QVariantMap &params) override;
+
+	qint64 createRecord(const QString &table, const Record &record) override;
+	bool updateRecord(const QString &table, qint64 id, const Record &record) override;
+	bool deleteRecord(const QString &table, qint64 id) override;
+private:
+	QSqlDatabase m_db;
+};
+
+} // namespace qf::core::sql

--- a/libqf/libqfcore/src/sql/qxsql.h
+++ b/libqf/libqfcore/src/sql/qxsql.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "recchng.h"
+#include "qxrecchng.h"
 
 #include <QList>
 #include <QMap>
@@ -55,10 +55,10 @@ public:
 		return listOneOrMoreRecords(table, fields, fromId, limit);
 	}
 
-	virtual qint64 createRecord(const QString &table, const Record &record);
+	virtual qint64 createRecord(const QString &table, const Record &record, const QString &issuer);
 	virtual std::optional<Record> readRecord(const QString &table, qint64 id, const std::optional<QStringList> &fields = std::nullopt);
-	virtual bool updateRecord(const QString &table, qint64 id, const Record &record);
-	virtual bool deleteRecord(const QString &table, qint64 id);
+	virtual bool updateRecord(const QString &table, qint64 id, const Record &record, const QString &issuer);
+	virtual bool deleteRecord(const QString &table, qint64 id, const QString &issuer);
 protected:
 	QList<Record> listOneOrMoreRecords(
 			const QString &table,
@@ -74,14 +74,14 @@ public:
 	QxSql(const QSqlDatabase &db = QSqlDatabase());
 	~QxSql() override = default;
 
-	Q_SIGNAL void dbRecChng(const qf::core::sql::RecChng &recchng);
+	Q_SIGNAL void dbRecChng(const qf::core::sql::QxRecChng &recchng);
 
 	QueryResult query(const QString &query, const QVariantMap &params) override;
 	ExecResult exec(const QString &query, const QVariantMap &params) override;
 
-	qint64 createRecord(const QString &table, const Record &record) override;
-	bool updateRecord(const QString &table, qint64 id, const Record &record) override;
-	bool deleteRecord(const QString &table, qint64 id) override;
+	qint64 createRecord(const QString &table, const Record &record, const QString &issuer) override;
+	bool updateRecord(const QString &table, qint64 id, const Record &record, const QString &issuer) override;
+	bool deleteRecord(const QString &table, qint64 id, const QString &issuer) override;
 private:
 	QSqlDatabase m_db;
 };

--- a/libqf/libqfcore/src/sql/recchng.cpp
+++ b/libqf/libqfcore/src/sql/recchng.cpp
@@ -1,0 +1,52 @@
+#include "recchng.h"
+
+#include "../core/log.h"
+
+namespace qf::core::sql {
+namespace {
+RecOp recopFromString(const QString &s)
+{
+	if (s == "Insert") return RecOp::Insert;
+	if (s == "Delete") return RecOp::Delete;
+	if (s == "Update") return RecOp::Update;
+	qfWarning() << "Undefined record operation:" << s;
+	return RecOp::Update;
+}
+}
+QVariantMap RecChng::toVariantMap() const
+{
+	QVariantMap ret;
+	ret["table"] = table;
+	ret["op"] = recopToString(op);
+	ret["id"] = id;
+	if (op != RecOp::Delete) {
+		ret["record"] = record;
+	}
+	if (!issuer.isEmpty()) {
+		ret["issuer"] = issuer;
+	}
+	return ret;
+}
+
+RecChng RecChng::fromVariantMap(const QVariantMap &m)
+{
+	RecChng ret;
+	ret.op = recopFromString(m.value("op").toString());
+	ret.id = m.value("id").value<qint64>();
+	if (ret.op != RecOp::Delete) {
+		ret.record = m.value("record").toMap();
+	}
+	ret.issuer = m.value("issuer").toString();
+	return ret;
+}
+
+QString RecChng::recopToString(RecOp op)
+{
+	switch (op) {
+	case RecOp::Insert: return "Insert";
+	case RecOp::Update: return "Update";
+	case RecOp::Delete: return "Delete";
+	}
+}
+
+}

--- a/libqf/libqfcore/src/sql/recchng.h
+++ b/libqf/libqfcore/src/sql/recchng.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "../core/coreglobal.h"
+
+#include <QString>
+#include <QVariantMap>
+
+namespace qf::core::sql {
+
+enum class RecOp {
+	Insert,
+	Update,
+	Delete,
+};
+
+struct QFCORE_DECL_EXPORT RecChng {
+	QString table;
+	qint64 id = 0;
+	QVariantMap record;
+	RecOp op = RecOp::Update;
+	QString issuer;
+
+	QVariantMap toVariantMap() const;
+	static RecChng fromVariantMap(const QVariantMap &m);
+	static QString recopToString(RecOp op);
+};
+}

--- a/libqf/libqfcore/src/utils/table.cpp
+++ b/libqf/libqfcore/src/utils/table.cpp
@@ -247,12 +247,11 @@ Table::Field::Field(const QString & _name, const QString & _def)
 //=========================================
 int Table::FieldList::fieldIndex(const QString &field_name) const
 {
-	int col = -1, i = 0;
+	int i = 0;
 	QString s = field_name;
 	foreach(Field fld, *this) {
 		if(Utils::fieldNameEndsWith(fld.name(), s)) {
-			col = i;
-			break;
+			return i;
 		}
 		i++;
 	}
@@ -269,7 +268,7 @@ int Table::FieldList::fieldIndex(const QString &field_name) const
 		return -1;
 	}
 	*/
-	return col;
+	return -1;
 }
 
 bool Table::FieldList::isValidFieldIndex(int fld_ix) const
@@ -477,8 +476,9 @@ void TableRow::setValue(int col, const QVariant &v)
 		return);
 
 	QVariant new_val;
-	if(v.isValid())
+	if(v.isValid()) {
 		new_val = Utils::retypeVariant(v, fields()[col].type().id());
+	}
 	QVariant orig_val = origValue(col);
 	//qfInfo() << new_val << "is null:" << new_val.isNull() << "==" << orig_val << "is null:" << orig_val.isNull() << "->" << (new_val == orig_val);
 	bool same_nullity = (new_val.isNull() && orig_val.isNull()) || (!new_val.isNull() && !orig_val.isNull());
@@ -504,11 +504,13 @@ void TableRow::setValue(const QString &field_name, const QVariant &v)
 void TableRow::restoreOrigValue(int col)
 {
 	qfLogFuncFrame() << "col:" << col;
-	QVariant orig_val = d->origValues.value(col);
-	/// pokud hodnota byla nastavena (napr. po opakovanem prenastaveni) nakonec na originalni, neni nutne ji ukladat
-	d->values[col] = orig_val;
-	if(col < d->dirtyFlags.count()) {
-		d->dirtyFlags[col] = false;
+	auto v = origValue(col);
+	if (col >= 0 && col < d->origValues.size() && col < d->values.size()) {
+		d->origValues[col] = v;
+		/// pokud hodnota byla nastavena (napr. po opakovanem prenastaveni) nakonec na originalni, neni nutne ji ukladat
+		if (d->values[col] == v && col < d->dirtyFlags.count()) {
+			d->dirtyFlags[col] = false;
+		}
 	}
 }
 
@@ -1309,8 +1311,8 @@ QVariant Table::sumValue(int field_ix) const
 	}
 	return ret;
 }
-
-static void setDomElementText(QDomDocument &owner_doc, QDomElement &el, const QString &str)
+namespace {
+void setDomElementText(QDomDocument &owner_doc, QDomElement &el, const QString &str)
 {
 	QDomNode nd = el.firstChild();
 	QDomText el_txt = nd.toText();
@@ -1322,7 +1324,7 @@ static void setDomElementText(QDomDocument &owner_doc, QDomElement &el, const QS
 		el_txt.setData(str);
 	}
 }
-
+}
 QDomElement Table::toHtmlElement(QDomDocument &owner_doc, const QString & col_names, TextExportOptions opts) const
 {
 	QList<int> ixs;

--- a/libqf/libqfcore/src/utils/table.h
+++ b/libqf/libqfcore/src/utils/table.h
@@ -7,7 +7,7 @@
 
 #include <QString>
 #include <QVariantMap>
-#include <QVector>
+#include <QList>
 #include <QBitArray>
 
 class QDomElement;
@@ -107,7 +107,7 @@ public:
 		qf::core::Collator sortCollator;
 	};
 protected:
-	typedef QVector<int> RowIndexList;
+	typedef QList<int> RowIndexList;
 public:
 	class QFCORE_DECL_EXPORT Field
 	{
@@ -333,8 +333,8 @@ private:
 	{
 		friend class TableRow;
 	public:
-		QVector<QVariant> values;
-		QVector<QVariant> origValues;
+		QList<QVariant> values;
+		QList<QVariant> origValues;
 		QBitArray dirtyFlags; ///< jsou situace, kdy je treba oznacit field jako dirty a pritom origValue a value jsou stejne
 		Table::TableProperties tableProperties;
 		struct Flags {
@@ -365,8 +365,8 @@ public:
 	QVariant value(int col) const;
 	QVariant value(const QString &field_name) const;
 
-	//QVector<QVariant>& valuesRef() {return d->values;}
-	const QVector<QVariant>& values() const {return d->values;}
+	//QList<QVariant>& valuesRef() {return d->values;}
+	const QList<QVariant>& values() const {return d->values;}
 	QVariantMap valuesMap(bool full_names = false) const;
 	QVariantMap dirtyValuesMap() const;
 

--- a/libqf/libqfgui/src/framework/application.cpp
+++ b/libqf/libqfgui/src/framework/application.cpp
@@ -3,6 +3,7 @@
 #include <qf/core/log.h>
 #include <qf/core/assert.h>
 #include <qf/core/utils/fileutils.h>
+#include <qf/core/sql/qxsql.h>
 
 #include <QQmlEngine>
 #include <QQmlContext>
@@ -17,19 +18,80 @@ Application::Application(int &argc, char **argv) :
 {
 }
 
+qint64 Application::createDbRecord(const QString &table, const QVariantMap &record) const
+{
+	using namespace qf::core::sql;
+	QxSql sql;
+	connect(&sql, &QxSql::dbRecChng, this, &Application::dbRecChng);
+	return sql.createRecord(table, record);
+}
+
+std::optional<QVariantMap> Application::readDbRecord(const QString &table, qint64 id, const std::optional<QStringList> &fields) const
+{
+	using namespace qf::core::sql;
+	QxSql sql;
+	return sql.readRecord(table, id, fields);
+}
+
+bool Application::updateDbRecord(const QString &table, qint64 id, const QVariantMap &record) const
+{
+	using namespace qf::core::sql;
+	QxSql sql;
+	connect(&sql, &QxSql::dbRecChng, this, &Application::dbRecChng);
+	return sql.updateRecord(table, id, record);
+}
+
+bool Application::deleteDbRecord(const QString &table, qint64 id) const
+{
+	using namespace qf::core::sql;
+	QxSql sql;
+	connect(&sql, &QxSql::dbRecChng, this, &Application::dbRecChng);
+	return sql.deleteRecord(table, id);
+}
+
 QString Application::versionString() const
 {
 	return QCoreApplication::applicationVersion();
 }
 
-Application::~Application()
-= default;
+void Application::emitDbRecInserted(const QString &table, qint64 id, const QVariantMap &record, const QString &issuer)
+{
+	emit dbRecChng(qf::core::sql::RecChng{
+		.table = table,
+		.id = id,
+		.record = record,
+		.op = qf::core::sql::RecOp::Insert,
+		.issuer = issuer
+	});
+}
+
+void Application::emitDbRecUpdated(const QString &table, qint64 id, const QVariantMap &record, const QString &issuer)
+{
+	emit dbRecChng(qf::core::sql::RecChng{
+		.table = table,
+		.id = id,
+		.record = record,
+		.op = qf::core::sql::RecOp::Update,
+		.issuer = issuer
+	});
+}
+
+void Application::emitDbRecDeleted(const QString &table, qint64 id, const QString &issuer)
+{
+	emit dbRecChng(qf::core::sql::RecChng{
+		.table = table,
+		.id = id,
+		.record = {},
+		.op = qf::core::sql::RecOp::Delete,
+		.issuer = issuer
+	});
+}
 
 Application *Application::instance(bool must_exist)
 {
 	auto *ret = qobject_cast<Application*>(Super::instance());
 	if(!ret && must_exist) {
-		qfFatal("qf::gui::framework::Application instance MUST exist.");
+		throw std::runtime_error("qf::gui::framework::Application instance MUST exist.");
 	}
 	return ret;
 }

--- a/libqf/libqfgui/src/framework/application.cpp
+++ b/libqf/libqfgui/src/framework/application.cpp
@@ -9,6 +9,7 @@
 #include <QQmlContext>
 #include <QFile>
 #include <QJsonParseError>
+#include <QUuid>
 
 namespace qfu = qf::core::utils;
 using namespace qf::gui::framework;
@@ -18,12 +19,12 @@ Application::Application(int &argc, char **argv) :
 {
 }
 
-qint64 Application::createDbRecord(const QString &table, const QVariantMap &record) const
+qint64 Application::createDbRecord(const QString &table, const QVariantMap &record, QObject *source)
 {
 	using namespace qf::core::sql;
 	QxSql sql;
-	connect(&sql, &QxSql::dbRecChng, this, &Application::dbRecChng);
-	return sql.createRecord(table, record);
+	connect(&sql, &QxSql::dbRecChng, this, [this, source](const qf::core::sql::QxRecChng &recchng) { emit qxRecChng(recchng, source); });
+	return sql.createRecord(table, record, uuidString());
 }
 
 std::optional<QVariantMap> Application::readDbRecord(const QString &table, qint64 id, const std::optional<QStringList> &fields) const
@@ -33,20 +34,20 @@ std::optional<QVariantMap> Application::readDbRecord(const QString &table, qint6
 	return sql.readRecord(table, id, fields);
 }
 
-bool Application::updateDbRecord(const QString &table, qint64 id, const QVariantMap &record) const
+bool Application::updateDbRecord(const QString &table, qint64 id, const QVariantMap &record, QObject *source)
 {
 	using namespace qf::core::sql;
 	QxSql sql;
-	connect(&sql, &QxSql::dbRecChng, this, &Application::dbRecChng);
-	return sql.updateRecord(table, id, record);
+	connect(&sql, &QxSql::dbRecChng, this, [this, source](const qf::core::sql::QxRecChng &recchng) { emit qxRecChng(recchng, source); });
+	return sql.updateRecord(table, id, record, uuidString());
 }
 
-bool Application::deleteDbRecord(const QString &table, qint64 id) const
+bool Application::deleteDbRecord(const QString &table, qint64 id, QObject *source)
 {
 	using namespace qf::core::sql;
 	QxSql sql;
-	connect(&sql, &QxSql::dbRecChng, this, &Application::dbRecChng);
-	return sql.deleteRecord(table, id);
+	connect(&sql, &QxSql::dbRecChng, this, [this, source](const qf::core::sql::QxRecChng &recchng) { emit qxRecChng(recchng, source); });
+	return sql.deleteRecord(table, id, uuidString());
 }
 
 QString Application::versionString() const
@@ -54,37 +55,42 @@ QString Application::versionString() const
 	return QCoreApplication::applicationVersion();
 }
 
-void Application::emitDbRecInserted(const QString &table, qint64 id, const QVariantMap &record, const QString &issuer)
+void Application::emitDbRecInserted(const QString &table, qint64 id, const QVariantMap &record, QObject *source)
 {
-	emit dbRecChng(qf::core::sql::RecChng{
+	emit qxRecChng(qf::core::sql::QxRecChng{
 		.table = table,
 		.id = id,
 		.record = record,
 		.op = qf::core::sql::RecOp::Insert,
-		.issuer = issuer
-	});
+		.issuer = uuidString()
+	}, source);
 }
 
-void Application::emitDbRecUpdated(const QString &table, qint64 id, const QVariantMap &record, const QString &issuer)
+void Application::emitDbRecUpdated(const QString &table, qint64 id, const QVariantMap &record, QObject *source)
 {
-	emit dbRecChng(qf::core::sql::RecChng{
+	emit qxRecChng(qf::core::sql::QxRecChng{
 		.table = table,
 		.id = id,
 		.record = record,
 		.op = qf::core::sql::RecOp::Update,
-		.issuer = issuer
-	});
+		.issuer = uuidString()
+	}, source);
 }
 
-void Application::emitDbRecDeleted(const QString &table, qint64 id, const QString &issuer)
+void Application::emitDbRecDeleted(const QString &table, qint64 id, QObject *source)
 {
-	emit dbRecChng(qf::core::sql::RecChng{
+	emit qxRecChng(qf::core::sql::QxRecChng{
 		.table = table,
 		.id = id,
 		.record = {},
 		.op = qf::core::sql::RecOp::Delete,
-		.issuer = issuer
-	});
+		.issuer = uuidString()
+	}, source);
+}
+
+void Application::emitQxRecChng(const core::sql::QxRecChng &recchng, QObject *source)
+{
+	emit qxRecChng(recchng, source);
 }
 
 Application *Application::instance(bool must_exist)
@@ -117,6 +123,18 @@ QStringList Application::arguments()
 	return QCoreApplication::arguments();
 }
 
+QUuid Application::uuid()
+{
+	static auto uuid = QUuid::createUuid();
+	return uuid;
+}
+
+QString Application::uuidString()
+{
+	static auto s = uuid().toString(QUuid::WithoutBraces);
+	return s;
+}
+
 void Application::loadStyleSheet(const QString &file)
 {
 	QString css_file_name = file;
@@ -137,4 +155,3 @@ void Application::loadStyleSheet(const QString &file)
 		qfWarning() << "Cannot open style sheet:" << css_file_name;
 	}
 }
-

--- a/libqf/libqfgui/src/framework/application.h
+++ b/libqf/libqfgui/src/framework/application.h
@@ -3,6 +3,8 @@
 
 #include "../guiglobal.h"
 
+#include <qf/core/sql/recchng.h>
+
 #include <QApplication>
 #include <QJsonDocument>
 #include <QQmlError>
@@ -23,7 +25,16 @@ private:
 	typedef QApplication Super;
 public:
 	explicit Application(int & argc, char ** argv);
-	~Application() override;
+	~Application() override = default;
+
+	Q_SIGNAL void dbRecChng(const qf::core::sql::RecChng &recchng);
+	qint64 createDbRecord(const QString &table, const QVariantMap &record) const;
+	std::optional<QVariantMap> readDbRecord(const QString &table, qint64 id, const std::optional<QStringList> &fields = std::nullopt) const;
+	bool updateDbRecord(const QString &table, qint64 id, const QVariantMap &record) const;
+	bool deleteDbRecord(const QString &table, qint64 id) const;
+	void emitDbRecInserted(const QString &table, qint64 id, const QVariantMap &record, const QString &issuer = {});
+	void emitDbRecUpdated(const QString &table, qint64 id, const QVariantMap &record, const QString &issuer = {});
+	void emitDbRecDeleted(const QString &table, qint64 id, const QString &issuer = {});
 
 	Q_INVOKABLE QString versionString() const;
 public:

--- a/libqf/libqfgui/src/framework/application.h
+++ b/libqf/libqfgui/src/framework/application.h
@@ -3,10 +3,11 @@
 
 #include "../guiglobal.h"
 
-#include <qf/core/sql/recchng.h>
+#include <qf/core/sql/qxrecchng.h>
 
 #include <QApplication>
 #include <QJsonDocument>
+#include <QObject>
 #include <QQmlError>
 
 class QQmlEngine;
@@ -27,14 +28,15 @@ public:
 	explicit Application(int & argc, char ** argv);
 	~Application() override = default;
 
-	Q_SIGNAL void dbRecChng(const qf::core::sql::RecChng &recchng);
-	qint64 createDbRecord(const QString &table, const QVariantMap &record) const;
+	Q_SIGNAL void qxRecChng(const qf::core::sql::QxRecChng &recchng, QObject *source);
+	qint64 createDbRecord(const QString &table, const QVariantMap &record, QObject *source);
 	std::optional<QVariantMap> readDbRecord(const QString &table, qint64 id, const std::optional<QStringList> &fields = std::nullopt) const;
-	bool updateDbRecord(const QString &table, qint64 id, const QVariantMap &record) const;
-	bool deleteDbRecord(const QString &table, qint64 id) const;
-	void emitDbRecInserted(const QString &table, qint64 id, const QVariantMap &record, const QString &issuer = {});
-	void emitDbRecUpdated(const QString &table, qint64 id, const QVariantMap &record, const QString &issuer = {});
-	void emitDbRecDeleted(const QString &table, qint64 id, const QString &issuer = {});
+	bool updateDbRecord(const QString &table, qint64 id, const QVariantMap &record, QObject *source);
+	bool deleteDbRecord(const QString &table, qint64 id, QObject *source);
+	void emitDbRecInserted(const QString &table, qint64 id, const QVariantMap &record, QObject *source);
+	void emitDbRecUpdated(const QString &table, qint64 id, const QVariantMap &record, QObject *source);
+	void emitDbRecDeleted(const QString &table, qint64 id, QObject *source);
+	void emitQxRecChng(const qf::core::sql::QxRecChng &recchng, QObject *source);
 
 	Q_INVOKABLE QString versionString() const;
 public:
@@ -46,6 +48,9 @@ public:
 	QString applicationDirPath();
 	QString applicationName();
 	QStringList arguments();
+
+	static QUuid uuid();
+	static QString uuidString();
 protected:
 	MainWindow* m_frameWork = nullptr;
 };

--- a/libqf/libqfgui/src/model/sqltablemodel.cpp
+++ b/libqf/libqfgui/src/model/sqltablemodel.cpp
@@ -249,7 +249,7 @@ bool SqlTableModel::postRow(int row_no, bool throw_exc)
 						row_ref.setValue(serial_ix, v);
 						row_ref.setDirty(serial_ix, false);
 						if (auto *app = qobject_cast<qf::gui::framework::Application*>(QApplication::instance()); app) {
-							app->emitDbRecInserted(table_id, v.value<qint64>(), record_to_map(rec));
+							app->emitDbRecInserted(table_id, v.value<qint64>(), record_to_map(rec), this);
 						}
 					}
 					else {
@@ -348,7 +348,7 @@ bool SqlTableModel::postRow(int row_no, bool throw_exc)
 				if (num_rows_affected == 1) {
 					if (where_rec.count() == 1) {
 						if (auto *app = qobject_cast<qf::gui::framework::Application*>(QApplication::instance()); app) {
-							app->emitDbRecUpdated(table_id, where_rec.value(0).value<qint64>(), record_to_map(edit_rec));
+							app->emitDbRecUpdated(table_id, where_rec.value(0).value<qint64>(), record_to_map(edit_rec), this);
 						}
 					}
 				}
@@ -457,7 +457,7 @@ bool SqlTableModel::removeTableRow(int row_no, bool throw_exc)
 			if (num_rows_affected == 1) {
 				if (where_rec.count() == 1) {
 					if (auto *app = qobject_cast<qf::gui::framework::Application*>(QApplication::instance()); app) {
-						app->emitDbRecDeleted(table_id, where_rec.value(0).value<qint64>());
+						app->emitDbRecDeleted(table_id, where_rec.value(0).value<qint64>(), this);
 					}
 				}
 			} else {

--- a/libqf/libqfgui/src/model/sqltablemodel.cpp
+++ b/libqf/libqfgui/src/model/sqltablemodel.cpp
@@ -1,5 +1,7 @@
 #include "sqltablemodel.h"
 
+#include <qf/gui/framework/application.h>
+
 #include <qf/core/assert.h>
 #include <qf/core/utils.h>
 #include <qf/core/exception.h>
@@ -125,7 +127,17 @@ bool SqlTableModel::reloadQuery(const QString &query_str)
 	emit reloaded();
 	return ok;
 }
-
+namespace {
+QVariantMap record_to_map(const QSqlRecord &rec)
+{
+	QVariantMap m;
+	for (int i = 0; i < rec.count(); ++i) {
+		const auto &fld = rec.field(i);
+		m[fld.name().toLower()] = fld.value();
+	}
+	return m;
+}
+}
 bool SqlTableModel::postRow(int row_no, bool throw_exc)
 {
 	qfLogFuncFrame() << row_no;
@@ -152,7 +164,7 @@ bool SqlTableModel::postRow(int row_no, bool throw_exc)
 			int primary_ix = -1;
 			//QSqlIndex pri_ix = ti.primaryIndex();
 			//bool has_blob_field = false;
-			Q_FOREACH(const qf::core::utils::Table::Field &fld, row_ref.fields()) {
+			for (const auto &fld : row_ref.fields()) {
 				i++;
 				if(fld.tableId() != table_id)
 					continue;
@@ -236,6 +248,9 @@ bool SqlTableModel::postRow(int row_no, bool throw_exc)
 					if(v.isValid()) {
 						row_ref.setValue(serial_ix, v);
 						row_ref.setDirty(serial_ix, false);
+						if (auto *app = qobject_cast<qf::gui::framework::Application*>(QApplication::instance()); app) {
+							app->emitDbRecInserted(table_id, v.value<qint64>(), record_to_map(rec));
+						}
 					}
 					else {
 						qfWarning() << "Serial field will not be initialized properly. This can make current transaction aborted.";
@@ -266,12 +281,12 @@ bool SqlTableModel::postRow(int row_no, bool throw_exc)
 		qfDebug() << "\tEDIT";
 		qf::core::sql::Connection sql_conn = sqlConnection();
 		QSqlDriver *sqldrv = sql_conn.driver();
-		Q_FOREACH(QString table_id, tableIds(m_table.fields())) {
+		for (const auto &table_id : tableIds(m_table.fields())) {
 			qfDebug() << "\ttableid:" << table_id;
 			//table = conn.fullTableNameToQtDriverTableName(table);
 			QSqlRecord edit_rec;
 			int i = -1;
-			Q_FOREACH(qfu::Table::Field fld, row_ref.fields()) {
+			for (const auto &fld : row_ref.fields()) {
 				i++;
 				//qfDebug() << "\t\tfield:" << fld.toString();
 				if(fld.tableId() != table_id)
@@ -300,7 +315,7 @@ bool SqlTableModel::postRow(int row_no, bool throw_exc)
 				query_str += " ";
 				QSqlRecord where_rec;
 				qfDebug() << "looking for primary index of table:" << table_id;
-				Q_FOREACH(auto fld_name, sql_conn.primaryIndexFieldNames(table_id)) {
+				for(const auto &fld_name : sql_conn.primaryIndexFieldNames(table_id)) {
 					QString full_fld_name = table_id + '.' + fld_name;
 					qfDebug() << "\t checking value of field:" << full_fld_name;
 					int fld_ix = m_table.fields().fieldIndex(full_fld_name);
@@ -330,7 +345,14 @@ bool SqlTableModel::postRow(int row_no, bool throw_exc)
 				qfDebug() << "\tnum rows affected:" << num_rows_affected;
 				/// if update command does not really change data for ex. (UPDATE woffice.kontakty SET id=8 WHERE id = 8)
 				/// numRowsAffected() returns 0.
-				if(num_rows_affected > 1) {
+				if (num_rows_affected == 1) {
+					if (where_rec.count() == 1) {
+						if (auto *app = qobject_cast<qf::gui::framework::Application*>(QApplication::instance()); app) {
+							app->emitDbRecUpdated(table_id, where_rec.value(0).value<qint64>(), record_to_map(edit_rec));
+						}
+					}
+				}
+				else if (num_rows_affected > 1) {
 					qfError() << QString("numRowsAffected() = %1, sholuld be 1 or 0\n%2").arg(num_rows_affected).arg(query_str);
 					ret = false;
 					break;
@@ -359,7 +381,7 @@ bool SqlTableModel::removeTableRow(int row_no, bool throw_exc)
 		QStringList table_ids = tableIdsSortedAccordingToForeignKeys();
 		QSet<QString> referenced_foreign_tables = referencedForeignTables();
 		int table_id_cnt = 0;
-		Q_FOREACH(const QString &table_id, table_ids) {
+		for (const auto &table_id : table_ids) {
 			/// Allways delete in first table
 			if(table_id_cnt++ > 0) {
 				/// delete in rest of the tables only if they are implicitly referenced, see: addForeignKeyDependency(...)
@@ -376,7 +398,7 @@ bool SqlTableModel::removeTableRow(int row_no, bool throw_exc)
 			query_str += sqldrv->sqlStatement(QSqlDriver::DeleteStatement, table, rec, false);
 			query_str += " ";
 			QSqlRecord where_rec;
-			Q_FOREACH(QString fld_name, sql_conn.primaryIndexFieldNames(table_id)) {
+			for (const auto &fld_name : sql_conn.primaryIndexFieldNames(table_id)) {
 				QString full_fld_name = table_id + '.' + fld_name;
 				int fld_ix = m_table.fields().fieldIndex(full_fld_name);
 				QF_ASSERT(fld_ix >= 0,
@@ -432,7 +454,13 @@ bool SqlTableModel::removeTableRow(int row_no, bool throw_exc)
 			int num_rows_affected = q.numRowsAffected();
 			/// if update command does not really change data for ex. (UPDATE woffice.kontakty SET id=8 WHERE id = 8)
 			/// numRowsAffected() returns 0.
-			if(num_rows_affected != 1) {
+			if (num_rows_affected == 1) {
+				if (where_rec.count() == 1) {
+					if (auto *app = qobject_cast<qf::gui::framework::Application*>(QApplication::instance()); app) {
+						app->emitDbRecDeleted(table_id, where_rec.value(0).value<qint64>());
+					}
+				}
+			} else {
 				qfError() << QString("numRowsAffected() = %1, sholuld be 1\n%2").arg(num_rows_affected).arg(query_str);
 				ret = false;
 				break;

--- a/libqf/libqfgui/src/model/sqltablemodel.h
+++ b/libqf/libqfgui/src/model/sqltablemodel.h
@@ -27,7 +27,7 @@ private:
 	typedef TableModel Super;
 public:
 	SqlTableModel(QObject *parent = nullptr);
-	~SqlTableModel() Q_DECL_OVERRIDE;
+	~SqlTableModel() override;
 
 	QF_PROPERTY_IMPL(QVariant, q, Q, ueryParameters)
 	QF_PROPERTY_BOOL_IMPL(i, I, ncludeJoinedTablesIdsToReloadRowQuery)
@@ -42,14 +42,14 @@ public:
 		DbEnumCastProperties(const QVariantMap &m = QVariantMap()) : QVariantMap(m) {}
 };
 public:
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
 	Q_INVOKABLE QString effectiveQuery();
-	bool reload() Q_DECL_OVERRIDE;
-	bool postRow(int row_no, bool throw_exc) Q_DECL_OVERRIDE;
-	void revertRow(int row_no) Q_DECL_OVERRIDE;
-	int reloadRow(int row_no) Q_DECL_OVERRIDE;
-	int reloadInserts(const QString &id_column_name) Q_DECL_OVERRIDE;
+	bool reload() override;
+	bool postRow(int row_no, bool throw_exc) override;
+	void revertRow(int row_no) override;
+	int reloadRow(int row_no) override;
+	int reloadInserts(const QString &id_column_name) override;
 	QString reloadRowQuery(const QVariant &record_id);
 public:
 	void setQueryBuilder(const qf::core::sql::QueryBuilder &qb, bool clear_columns = false);
@@ -88,7 +88,7 @@ protected:
 	QSet<QString> referencedForeignTables();
 	QStringList tableIdsSortedAccordingToForeignKeys();
 
-	bool removeTableRow(int row_no, bool throw_exc = false) Q_DECL_OVERRIDE;
+	bool removeTableRow(int row_no, bool throw_exc = false) override;
 protected:
 	qf::core::sql::QueryBuilder m_queryBuilder;
 	QString m_query;

--- a/libqf/libqfgui/src/model/tablemodel.cpp
+++ b/libqf/libqfgui/src/model/tablemodel.cpp
@@ -5,6 +5,7 @@
 #include <qf/core/assert.h>
 #include <qf/core/utils.h>
 #include <qf/core/utils/treetable.h>
+#include <qf/core/sql/qxrecchng.h>
 
 #include <QTime>
 #include <QTimeZone>
@@ -450,7 +451,7 @@ bool TableModel::setValue(int row, int column, const QVariant &val)
 	//QVariant v = val;
 	//if(isNullReportedAsString() && v.toString() == qfc::Utils::nullValueString())
 	//	v = QVariant();
-	qfu::TableRow &r = m_table.rowRef(row);
+	auto &r = m_table.rowRef(row);
 	r.setValue(table_field_index, val);
 	ret = true;
 
@@ -481,7 +482,7 @@ void TableModel::restoreOrigValue(int row, int column)
 	//QVariant v = val;
 	//if(isNullReportedAsString() && v.toString() == qfc::Utils::nullValueString())
 	//	v = QVariant();
-	qfu::TableRow &r = m_table.rowRef(row);
+	auto &r = m_table.rowRef(row);
 	r.restoreOrigValue(table_field_index);
 }
 
@@ -653,9 +654,65 @@ int TableModel::columnType(int column_index) const
 	return ret;
 }
 
+std::optional<int> TableModel::columnIndexOfTableField(const QString &field_name) const
+{
+	if (auto fld_ix = m_table.fields().fieldIndex(field_name); fld_ix >= 0) {
+		for (int i = 0; i < m_columns.size(); ++i) {
+			const auto &cd = m_columns[i];
+			if (cd.fieldIndex() == fld_ix) {
+				return i;
+			}
+		}
+	}
+	return {};
+}
+
 QColor TableModel::contrastTextColor(const QColor &background_color)
 {
 	return (qGray(background_color.rgb()) < 128)? QColor(Qt::white) : QColor(Qt::black);
+}
+
+void TableModel::handleQxRecChng(const core::sql::QxRecChng &recchng, QObject *source)
+{
+	// qfInfo() << __FUNCTION__ << source;
+	if (source == this) {
+		return;
+	}
+	auto find_row_by_id = [this](const QString &table_name, int id) {
+		if (auto fld_ix = table().fields().fieldIndex(table_name + ".id"); fld_ix >= 0) {
+			for (int i = 0; i < rowCount(); ++i) {
+				if (table().row(i).value(fld_ix).toInt() == id) {
+					return i;
+				}
+			}
+		} else {
+			qfWarning() << "cannot find table column:" << (table_name + ".id");
+		}
+		return -1;
+	};
+	if (recchng.op == qf::core::sql::RecOp::Update) {
+		if (int row = find_row_by_id(recchng.table, recchng.id); row >= 0) {
+			for (const auto &[k, v] : recchng.record.asKeyValueRange()) {
+				if (auto col_ix = columnIndexOfTableField(recchng.table + '.' + k); col_ix.has_value()) {
+					// Q_ASSERT(0 <= row && row < m_table.rowCount());
+					const auto &cd = columnDefinition(col_ix.value());
+					Q_ASSERT(cd.fieldIndex() >= 0);
+					auto &r = m_table.rowRef(row);
+					if (!r.isDirty(cd.fieldIndex())) {
+						// do not update current edits
+						qfMessage() << "updating orig value, row:" << row << (recchng.table + '.' + k) << "-->" << v;
+						r.setBareBoneValue(cd.fieldIndex(), v);
+						auto ix = index(row, col_ix.value());
+						emit dataChanged(ix, ix);
+					}
+				} else {
+					// calculated column
+					qfInfo() << "reloading calculated field, row:" << row << (recchng.table + '.' + k) << "-->" << v;
+					reloadRow(row);
+				}
+			}
+		}
+	}
 }
 
 QVariant TableModel::rawValueToEdit(int column_index, const QVariant &val) const
@@ -673,7 +730,7 @@ QVariant TableModel::editValueToRaw(int column_index, const QVariant &val) const
 int TableModel::columnIndex(const QString &column_name) const
 {
 	int ret = -1, i = 0;
-	Q_FOREACH(auto cd, m_columns) {
+	for (const auto &cd : m_columns) {
 		//qfInfo() << cd.fieldName() << "vs." << column_name;
 		if(qfc::Utils::fieldNameEndsWith(cd.fieldName(), column_name)) {
 			ret = i;
@@ -683,8 +740,9 @@ int TableModel::columnIndex(const QString &column_name) const
 	}
 	if(ret < 0) {
 		QStringList sl;
-		Q_FOREACH(const ColumnDefinition &cd, m_columns)
+		for (const auto &cd : m_columns) {
 			sl << cd.fieldName();
+		}
 		QString s = sl.join(", ");
 		QString msg = tr("Column named '%1' not found in column list. Existing columns: [%2]").arg(column_name).arg(s);
 		qfError() << msg;
@@ -694,13 +752,12 @@ int TableModel::columnIndex(const QString &column_name) const
 
 int TableModel::tableFieldIndex(int column_index) const
 {
-	int ret = -1;
 	ColumnDefinition cd = m_columns.value(column_index);
-	QF_ASSERT(!cd.isNull(),
-			  tr("Invalid column index: %1").arg(column_index),
-			  return ret);
-	ret = cd.fieldIndex();
-	return ret;
+	if (cd.isNull()) {
+			  qfWarning() << "Invalid column index:" << column_index;
+			  return -1;
+	}
+	return cd.fieldIndex();
 }
 
 qf::core::utils::Table::Field TableModel::tableField(int column_index) const

--- a/libqf/libqfgui/src/model/tablemodel.h
+++ b/libqf/libqfgui/src/model/tablemodel.h
@@ -7,6 +7,8 @@
 
 #include <QAbstractTableModel>
 
+namespace qf::core::sql { struct QxRecChng; }
+
 namespace qf {
 namespace gui {
 
@@ -113,7 +115,7 @@ public:
 
 		bool matchesSqlId(const QString column_name) const;
 	};
-	typedef QVector<ColumnDefinition> ColumnList;
+	typedef QList<ColumnDefinition> ColumnList;
 
 public:
 	void clearRows();
@@ -200,11 +202,14 @@ public:
 	ColumnDefinition columnDefinition(int ix) const;
 	int columnIndex(const QString &column_name) const;
 	int columnType(int column_index) const;
+	std::optional<int> columnIndexOfTableField(const QString &field_name) const;
 
 	int tableFieldIndex(int column_index) const;
 	qf::core::utils::Table::Field tableField(int column_index) const;
 
 	static QColor contrastTextColor(const QColor &background_color);
+
+	void handleQxRecChng(const qf::core::sql::QxRecChng &recchng, QObject *source);
 protected:
 	virtual void checkColumns();
 	void createColumnsFromTableFields();

--- a/libquickevent/libquickeventcore/src/si/checkedcard.h
+++ b/libquickevent/libquickeventcore/src/si/checkedcard.h
@@ -31,6 +31,7 @@ private:
 	QF_VARIANTMAP_FIELD(bool, is, set, BadCheck)
 	QF_VARIANTMAP_FIELD(bool, is, set, MisPunch)
 	QF_VARIANTMAP_FIELD(QVariantMap, d, setD, ata)
+	QF_VARIANTMAP_FIELD(QVariantList, m, setM, issingCodes)
 public:
 	CheckedCard(const QVariantMap &data = QVariantMap());
 

--- a/libsiut/src/device/sitask.cpp
+++ b/libsiut/src/device/sitask.cpp
@@ -649,7 +649,7 @@ void SiTaskReadCard8::onSiMessageReceived(const SIMessageData &msg)
 			int station_number = (int)SIPunch::getUnsigned(data, base - 3);
 			int card_number = (int)SIPunch::getUnsigned(data, base + 0x19, 3);
 			m_cardSerie = static_cast<CardSerie>(((uint8_t)data[base + 0x18]) & 15);
-			qfInfo() << "CS:" << m_cardSerie;
+			// qfInfo() << "CS:" << m_cardSerie;
 			logCardRead() << "CS:" << m_cardSerie << cardSerieToString(m_cardSerie) << "SI:" << card_number;
 			m_card.setStationNumber(station_number);
 			m_card.setCardNumber(card_number);

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardcheckerclassiccpp.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardcheckerclassiccpp.cpp
@@ -101,22 +101,24 @@ quickevent::core::si::CheckedCard CardCheckerClassicCpp::checkCard(const quickev
 		}
 	}
 
+	QVariantList missing_codes;
 	int read_punch_check_ix = 0;
 	for(int j=0; j<course_codes.length(); j++) {
 		quickevent::core::CodeDef course_code(course_codes[j].toMap());
 		quickevent::core::si::CheckedPunch checked_punch = quickevent::core::si::CheckedPunch::fromCodeDef(course_code);
 		//checked_punch.setCode(course_code.value(QStringLiteral("code")).toInt());
+		int code = course_code.value(QStringLiteral("code")).toInt();
+		int alt_code = course_code.value(QStringLiteral("altcode")).toInt();
 		int k;
 		for(k=read_punch_check_ix; k<read_punches.length(); k++) { //scan card
 			const quickevent::core::si::ReadPunch &read_punch = read_punches[k];
-			int code = course_code.value(QStringLiteral("code")).toInt();
-			int alt_code = course_code.value(QStringLiteral("altcode")).toInt();
 			qfDebug() << j << k << "looking for:" << checked_punch.code() << "on card:" << read_punch.code() << "vs. code:" << code << "alt:" << alt_code;
 			//console.info("code:", JSON.stringify(course_code, null, 2));
 			if(read_punch.code() == code || read_punch.code() == alt_code) {
 				int read_punch_time_ms = read_punch.time() * 1000;
-				if(read_punch.msec())
+				if(read_punch.msec()) {
 					read_punch_time_ms += read_punch.msec();
+				}
 				checked_punch.setStpTimeMs(msecIntervalAM(checked_card.stageStartTimeMs() + checked_card.startTimeMs(), read_punch_time_ms));
 				qfDebug() << j << "OK";
 				break;
@@ -126,8 +128,10 @@ quickevent::core::si::CheckedCard CardCheckerClassicCpp::checkCard(const quickev
 			// code not found
 			qfDebug() << j << "NOT FOUND";
 			bool code_ooo = course_code.value(QStringLiteral("outoforder")).toBool();
-			if(!code_ooo) // for postgres, Query.values() should return lower case keys
+			if(!code_ooo) {// for postgres, Query.values() should return lower case keys
 				error_mis_punch = true;
+				missing_codes.insert(missing_codes.size(), QVariantList{ j+1, code });
+			}
 		}
 		else {
 			read_punch_check_ix = k + 1;
@@ -135,6 +139,7 @@ quickevent::core::si::CheckedCard CardCheckerClassicCpp::checkCard(const quickev
 		checked_punches << checked_punch;
 	}
 	checked_card.setMisPunch(error_mis_punch);
+	checked_card.setMissingCodes(missing_codes);
 
 	quickevent::core::si::CheckedPunch finish_punch;
 	if(!finish_code.isEmpty())
@@ -156,8 +161,9 @@ quickevent::core::si::CheckedCard CardCheckerClassicCpp::checkCard(const quickev
 	}
 	{
 		QVariantList lst;
-		for(const quickevent::core::si::CheckedPunch &p : checked_punches)
+		for(const quickevent::core::si::CheckedPunch &p : checked_punches) {
 			lst << p;
+		}
 		checked_card.setPunches(lst);
 	}
 	qfDebug() << "check result:" << checked_card.toString();

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
@@ -287,28 +287,6 @@ int CardReaderPlugin::saveCardToSql(const quickevent::core::si::ReadCard &read_c
 		qfError() << "Update runs error, query:" << e.what();
 		return 0;
 	}
-	// qf::core::sql::Query q;
-	// q.prepare(QStringLiteral("INSERT INTO cards (stationNumber, siId, checkTime, startTime, finishTime, punches, runId, stageId, readerConnectionId, runIdAssignError, data)"
-	// 						 " VALUES (:stationNumber, :siId, :checkTime, :startTime, :finishTime, :punches, :runId, :stageId, :readerConnectionId, :runIdAssignError, :data)")
-	// 		  , qf::core::Exception::Throw);
-	// q.bindValue(QStringLiteral(":stationNumber"), read_card.stationNumber());
-	// q.bindValue(QStringLiteral(":siId"), read_card.cardNumber());
-	// q.bindValue(QStringLiteral(":checkTime"), read_card.checkTime());
-	// q.bindValue(QStringLiteral(":startTime"), read_card.startTime());
-	// q.bindValue(QStringLiteral(":finishTime"), read_card.finishTime());
-	// q.bindValue(QStringLiteral(":punches"), '[' + punches.join(", ") + ']');
-	// q.bindValue(QStringLiteral(":runId"), read_card.runId());
-	// q.bindValue(QStringLiteral(":stageId"), currentStageId());
-	// q.bindValue(QStringLiteral(":readerConnectionId"), qf::core::sql::Connection::defaultConnection().connectionId());
-	// q.bindValue(QStringLiteral(":runIdAssignError"), read_card.runIdAssignError());
-	// q.bindValue(QStringLiteral(":data"), qf::core::Utils::qvariantToJson(read_card.data()));
-	// if(q.exec()) {
-	// 	ret = q.lastInsertId().toInt();
-	// }
-	// else {
-	// 	qfError() << tr("Save card ERROR: %1").arg(q.lastErrorText());
-	// }
-	// return ret;
 }
 
 int CardReaderPlugin::savePunchRecordToSql(const quickevent::core::si::PunchRecord &punch_record)
@@ -383,7 +361,7 @@ int CardReaderPlugin::savePunchRecordToSql(const quickevent::core::si::PunchReco
 	// return ret;
 }
 
-void CardReaderPlugin::updateCheckedCardValuesSql(const quickevent::core::si::CheckedCard &checked_card) noexcept(false)
+void CardReaderPlugin::updateCheckedCardValuesSql(int card_id, const quickevent::core::si::CheckedCard &checked_card)
 {
 	QF_TIME_SCOPE("updateCheckedCardValuesSql()");
 	int run_id = checked_card.runId();
@@ -418,16 +396,29 @@ void CardReaderPlugin::updateCheckedCardValuesSql(const quickevent::core::si::Ch
 
 	try {
 		auto *app = qf::gui::framework::Application::instance();
-		QVariantMap rec {
-			{"checkTimeMs", checked_card.checkTimeMs()},
-			{"timeMs", checked_card.timeMs()},
-			{"finishTimeMs", checked_card.finishTimeMs()},
-			{"misPunch", checked_card.isMisPunch()},
-			{"badCheck", checked_card.isBadCheck()},
-			{"notStart", false},
-			{"penaltyTimeMs", {}},
-		};
-		app->updateDbRecord("runs", run_id, rec);
+		{
+			QVariantMap rec {
+				{"checkTimeMs", checked_card.checkTimeMs()},
+				{"timeMs", checked_card.timeMs()},
+				{"finishTimeMs", checked_card.finishTimeMs()},
+				{"misPunch", checked_card.isMisPunch()},
+				{"badCheck", checked_card.isBadCheck()},
+				{"notStart", false},
+				{"penaltyTimeMs", {}},
+			};
+			app->updateDbRecord("runs", run_id, rec);
+		}
+		if (auto missing_codes = checked_card.missingCodes(); !missing_codes.isEmpty()) {
+			QStringList missing_str;
+			for (const auto &vl : missing_codes) {
+				auto vll = vl.toList();
+				missing_codes << QStringLiteral("%1-%2").arg(vll.value(0).toInt()).arg(vll.value(1).toInt());
+			}
+			QVariantMap rec {
+				{"runIdAssignError", missing_str.join(',')},
+			};
+			app->updateDbRecord("cards", card_id, rec);
+		}
 	}
 	catch (const std::exception &e) {
 		qfError() << "Update runs error, query:" << e.what();
@@ -583,9 +574,9 @@ bool CardReaderPlugin::processCardToRunAssignment(int card_id, int run_id)
 				}
 			}
 		}
-		quickevent::core::si::CheckedCard checked_card = checkCard(card_id, run_id);
+		auto checked_card = checkCard(card_id, run_id);
 		//qfDebug() << checked_card.toString();
-		updateCheckedCardValuesSql(checked_card);
+		updateCheckedCardValuesSql(card_id, checked_card);
 		getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_CARD_PROCESSED_AND_ASSIGNED, checked_card, true);
 
 		q.execThrow("SELECT id, startTimeMs, finishTimeMs FROM runs"
@@ -620,8 +611,8 @@ bool CardReaderPlugin::processCardToRunAssignment(int card_id, int run_id)
 		}
 	}
 	else {
-		quickevent::core::si::CheckedCard checked_card = checkCard(card_id, run_id);
-		updateCheckedCardValuesSql(checked_card);
+		auto checked_card = checkCard(card_id, run_id);
+		updateCheckedCardValuesSql(card_id, checked_card);
 		getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_CARD_PROCESSED_AND_ASSIGNED, checked_card, true);
 	}
 	return true;

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
@@ -9,6 +9,9 @@
 #include "../../Core/src/coreplugin.h"
 #include "../../Core/src/widgets/settingsdialog.h"
 
+#include <plugins/Event/src/eventplugin.h>
+#include <plugins/Runs/src/runsplugin.h>
+
 #include <quickevent/core/og/timems.h>
 #include <quickevent/core/si/punchrecord.h>
 #include <quickevent/core/si/checkedcard.h>
@@ -16,6 +19,7 @@
 
 #include <qf/gui/framework/mainwindow.h>
 
+#include <qf/gui/framework/application.h>
 #include <qf/core/log.h>
 #include <qf/core/assert.h>
 #include <qf/core/exception.h>
@@ -23,8 +27,7 @@
 #include <qf/core/sql/connection.h>
 #include <qf/core/sql/transaction.h>
 #include <qf/core/sql/querybuilder.h>
-#include <plugins/Event/src/eventplugin.h>
-#include <plugins/Runs/src/runsplugin.h>
+
 #include <QJSValue>
 #include <QMetaObject>
 #include <QSqlRecord>
@@ -257,40 +260,60 @@ int CardReaderPlugin::saveCardToSql(const quickevent::core::si::ReadCard &read_c
 			getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_PUNCH_RECEIVED, punch, true);
 		}
 	}
-	int ret = 0;
 	QStringList punches;
 	for(const auto &v : read_card.punches()) {
 		quickevent::core::si::ReadPunch p(v.toMap());
 		punches << p.toJsonArrayString();
 	}
-	qf::core::sql::Query q;
-	q.prepare(QStringLiteral("INSERT INTO cards (stationNumber, siId, checkTime, startTime, finishTime, punches, runId, stageId, readerConnectionId, runIdAssignError, data)"
-							 " VALUES (:stationNumber, :siId, :checkTime, :startTime, :finishTime, :punches, :runId, :stageId, :readerConnectionId, :runIdAssignError, :data)")
-			  , qf::core::Exception::Throw);
-	q.bindValue(QStringLiteral(":stationNumber"), read_card.stationNumber());
-	q.bindValue(QStringLiteral(":siId"), read_card.cardNumber());
-	q.bindValue(QStringLiteral(":checkTime"), read_card.checkTime());
-	q.bindValue(QStringLiteral(":startTime"), read_card.startTime());
-	q.bindValue(QStringLiteral(":finishTime"), read_card.finishTime());
-	q.bindValue(QStringLiteral(":punches"), '[' + punches.join(", ") + ']');
-	q.bindValue(QStringLiteral(":runId"), read_card.runId());
-	q.bindValue(QStringLiteral(":stageId"), currentStageId());
-	q.bindValue(QStringLiteral(":readerConnectionId"), qf::core::sql::Connection::defaultConnection().connectionId());
-	q.bindValue(QStringLiteral(":runIdAssignError"), read_card.runIdAssignError());
-	q.bindValue(QStringLiteral(":data"), qf::core::Utils::qvariantToJson(read_card.data()));
-	if(q.exec()) {
-		ret = q.lastInsertId().toInt();
+	try {
+		auto *app = qf::gui::framework::Application::instance();
+		QVariantMap rec {
+			{"stationNumber", read_card.stationNumber()},
+			{"siId", read_card.cardNumber()},
+			{"checkTime", read_card.checkTime()},
+			{"startTime", read_card.startTime()},
+			{"finishTime", read_card.finishTime()},
+			{"punches", '[' + punches.join(", ") + ']'},
+			{"runId", read_card.runId()},
+			{"stageId", currentStageId()},
+			{"readerConnectionId", qf::core::sql::Connection::defaultConnection().connectionId()},
+			{"runIdAssignError", read_card.runIdAssignError()},
+			{"data", qf::core::Utils::qvariantToJson(read_card.data())},
+		};
+		auto id = app->createDbRecord("cards", rec);
+		return id;
 	}
-	else {
-		qfError() << tr("Save card ERROR: %1").arg(q.lastErrorText());
+	catch (const std::exception &e) {
+		qfError() << "Update runs error, query:" << e.what();
+		return 0;
 	}
-	return ret;
+	// qf::core::sql::Query q;
+	// q.prepare(QStringLiteral("INSERT INTO cards (stationNumber, siId, checkTime, startTime, finishTime, punches, runId, stageId, readerConnectionId, runIdAssignError, data)"
+	// 						 " VALUES (:stationNumber, :siId, :checkTime, :startTime, :finishTime, :punches, :runId, :stageId, :readerConnectionId, :runIdAssignError, :data)")
+	// 		  , qf::core::Exception::Throw);
+	// q.bindValue(QStringLiteral(":stationNumber"), read_card.stationNumber());
+	// q.bindValue(QStringLiteral(":siId"), read_card.cardNumber());
+	// q.bindValue(QStringLiteral(":checkTime"), read_card.checkTime());
+	// q.bindValue(QStringLiteral(":startTime"), read_card.startTime());
+	// q.bindValue(QStringLiteral(":finishTime"), read_card.finishTime());
+	// q.bindValue(QStringLiteral(":punches"), '[' + punches.join(", ") + ']');
+	// q.bindValue(QStringLiteral(":runId"), read_card.runId());
+	// q.bindValue(QStringLiteral(":stageId"), currentStageId());
+	// q.bindValue(QStringLiteral(":readerConnectionId"), qf::core::sql::Connection::defaultConnection().connectionId());
+	// q.bindValue(QStringLiteral(":runIdAssignError"), read_card.runIdAssignError());
+	// q.bindValue(QStringLiteral(":data"), qf::core::Utils::qvariantToJson(read_card.data()));
+	// if(q.exec()) {
+	// 	ret = q.lastInsertId().toInt();
+	// }
+	// else {
+	// 	qfError() << tr("Save card ERROR: %1").arg(q.lastErrorText());
+	// }
+	// return ret;
 }
 
 int CardReaderPlugin::savePunchRecordToSql(const quickevent::core::si::PunchRecord &punch_record)
 {
 	//qfInfo() << "PUNCH:" << punch_record.toString();
-	int ret = 0;
 	quickevent::core::si::PunchRecord punch = punch_record;
 	punch.setstageid(currentStageId());
 
@@ -320,26 +343,44 @@ int CardReaderPlugin::savePunchRecordToSql(const quickevent::core::si::PunchReco
 			return 0;
 		}
 	}
-
-	q.prepare(QStringLiteral("INSERT INTO punches (siId, code, time, msec, runId, stageId, timeMs, runTimeMs)"
-							 " VALUES (:siId, :code, :time, :msec, :runId, :stageId, :timeMs, :runTimeMs)")
-							, qf::core::Exception::Throw);
-	q.bindValue(QStringLiteral(":siId"), punch.siid());
-	q.bindValue(QStringLiteral(":code"), code);
-	q.bindValue(QStringLiteral(":time"), punch.time());
-	q.bindValue(QStringLiteral(":msec"), punch.msec());
-	q.bindValue(QStringLiteral(":runId"), punch.runid());
-	q.bindValue(QStringLiteral(":stageId"), punch.stageid());
-	q.bindValue(QStringLiteral(":timeMs"), punch.timems());
-	q.bindValue(QStringLiteral(":runTimeMs"), punch.runtimems_isset()? punch.runtimems(): QVariant());
-	/// it is not possible to save punch time as date-time to be independent on start00 since it depends on start00 due to 12H time format
-	if(q.exec()) {
-		ret = q.lastInsertId().toInt();
+	try {
+		auto *app = qf::gui::framework::Application::instance();
+		QVariantMap rec {
+			{"siId", punch.siid()},
+			{"code", code},
+			{"time", punch.time()},
+			{"msec", punch.msec()},
+			{"runId", punch.runid()},
+			{"stageId", punch.stageid()},
+			{"timeMs", punch.timems()},
+			{"runTimeMs", punch.runtimems_isset()? punch.runtimems(): QVariant()},
+		};
+		auto id = app->createDbRecord("punches", rec);
+		return id;
 	}
-	else {
-		qfError() << tr("Save punch record ERROR: %1").arg(q.lastErrorText());
+	catch (const std::exception &e) {
+		qfError() << "Update runs error, query:" << e.what();
+		return 0;
 	}
-	return ret;
+	// q.prepare(QStringLiteral("INSERT INTO punches (siId, code, time, msec, runId, stageId, timeMs, runTimeMs)"
+	// 						 " VALUES (:siId, :code, :time, :msec, :runId, :stageId, :timeMs, :runTimeMs)")
+	// 						, qf::core::Exception::Throw);
+	// q.bindValue(QStringLiteral(":siId"), punch.siid());
+	// q.bindValue(QStringLiteral(":code"), code);
+	// q.bindValue(QStringLiteral(":time"), punch.time());
+	// q.bindValue(QStringLiteral(":msec"), punch.msec());
+	// q.bindValue(QStringLiteral(":runId"), punch.runid());
+	// q.bindValue(QStringLiteral(":stageId"), punch.stageid());
+	// q.bindValue(QStringLiteral(":timeMs"), punch.timems());
+	// q.bindValue(QStringLiteral(":runTimeMs"), punch.runtimems_isset()? punch.runtimems(): QVariant());
+	// /// it is not possible to save punch time as date-time to be independent on start00 since it depends on start00 due to 12H time format
+	// if(q.exec()) {
+	// 	ret = q.lastInsertId().toInt();
+	// }
+	// else {
+	// 	qfError() << tr("Save punch record ERROR: %1").arg(q.lastErrorText());
+	// }
+	// return ret;
 }
 
 void CardReaderPlugin::updateCheckedCardValuesSql(const quickevent::core::si::CheckedCard &checked_card) noexcept(false)
@@ -374,30 +415,38 @@ void CardReaderPlugin::updateCheckedCardValuesSql(const quickevent::core::si::Ch
 			}
 		}
 	}
-	//bool should_be_disq = false;
-	//{
-	//	q.execThrow("SELECT * FROM runs WHERE id=" + QString::number(run_id));
-	//	if(q.next()) {
-	//		if(q.value("disqualifiedByOrganizer").toBool()) should_be_disq = true;
-	//		if(q.value("notStart").toBool()) should_be_disq = true;
-	//		if(q.value("notFinish").toBool()) should_be_disq = true;
-	//	}
-	//}
-	QString qs = "UPDATE runs SET checkTimeMs=:checkTimeMs, timeMs=:timeMs, finishTimeMs=:finishTimeMs, penaltyTimeMs=NULL,"
-				 " misPunch=:misPunch, badCheck=:badCheck,"
-				 " notStart=:notStart"
-				 " WHERE id=" + QString::number(run_id);
-	q.prepare(qs, qf::core::Exception::Throw);
-	q.bindValue(QStringLiteral(":checkTimeMs"), checked_card.checkTimeMs());
-	q.bindValue(QStringLiteral(":timeMs"), checked_card.timeMs());
-	q.bindValue(QStringLiteral(":finishTimeMs"), checked_card.finishTimeMs());
-	q.bindValue(QStringLiteral(":misPunch"), checked_card.isMisPunch());
-	q.bindValue(QStringLiteral(":badCheck"), checked_card.isBadCheck());
-	q.bindValue(QStringLiteral(":notStart"), false);
-	q.exec(qf::core::Exception::Throw);
-	if(q.numRowsAffected() != 1) {
-		qfError() << "Update runs error, query:" << qs;
+
+	try {
+		auto *app = qf::gui::framework::Application::instance();
+		QVariantMap rec {
+			{"checkTimeMs", checked_card.checkTimeMs()},
+			{"timeMs", checked_card.timeMs()},
+			{"finishTimeMs", checked_card.finishTimeMs()},
+			{"misPunch", checked_card.isMisPunch()},
+			{"badCheck", checked_card.isBadCheck()},
+			{"notStart", false},
+			{"penaltyTimeMs", {}},
+		};
+		app->updateDbRecord("runs", run_id, rec);
 	}
+	catch (const std::exception &e) {
+		qfError() << "Update runs error, query:" << e.what();
+	}
+	// QString qs = "UPDATE runs SET checkTimeMs=:checkTimeMs, timeMs=:timeMs, finishTimeMs=:finishTimeMs, penaltyTimeMs=NULL,"
+	// 			 " misPunch=:misPunch, badCheck=:badCheck,"
+	// 			 " notStart=:notStart"
+	// 			 " WHERE id=" + QString::number(run_id);
+	// q.prepare(qs, qf::core::Exception::Throw);
+	// q.bindValue(QStringLiteral(":checkTimeMs"), checked_card.checkTimeMs());
+	// q.bindValue(QStringLiteral(":timeMs"), checked_card.timeMs());
+	// q.bindValue(QStringLiteral(":finishTimeMs"), checked_card.finishTimeMs());
+	// q.bindValue(QStringLiteral(":misPunch"), checked_card.isMisPunch());
+	// q.bindValue(QStringLiteral(":badCheck"), checked_card.isBadCheck());
+	// q.bindValue(QStringLiteral(":notStart"), false);
+	// q.exec(qf::core::Exception::Throw);
+	// if(q.numRowsAffected() != 1) {
+	// 	qfError() << "Update runs error, query:" << qs;
+	// }
 }
 
 void CardReaderPlugin::updateCardToRunAssignmentInPunches(int stage_id, int card_id, int run_id)
@@ -417,14 +466,26 @@ void CardReaderPlugin::updateCardToRunAssignmentInPunches(int stage_id, int card
 
 bool CardReaderPlugin::saveCardAssignedRunnerIdSql(int card_id, int run_id)
 {
-	QF_TIME_SCOPE("saveCardAssignedRunnerIdSql()");
-	auto cc = qf::core::sql::Connection::forName();
-	qf::core::sql::Query q(cc);
-	QString now = QStringLiteral("now()");
-	if(cc.driverName().endsWith("SQLITE", Qt::CaseInsensitive))
-		now = QStringLiteral("CURRENT_TIMESTAMP");
-	bool ret = q.exec("UPDATE cards SET runId=" QF_IARG(run_id) ", runIdAssignTS=" + now + " WHERE id=" QF_IARG(card_id), !qf::core::Exception::Throw);
-	return ret;
+	try {
+		auto *app = qf::gui::framework::Application::instance();
+		QVariantMap rec {
+			{"runId", run_id},
+			{"runIdAssignTS", QDateTime::currentDateTime()},
+		};
+		app->updateDbRecord("cards", card_id, rec);
+		return true;
+	}
+	catch (const std::exception &e) {
+		qfError() << "Update runs error, query:" << e.what();
+		return false;
+	}
+	// QF_TIME_SCOPE("saveCardAssignedRunnerIdSql()");
+	// auto cc = qf::core::sql::Connection::forName();
+	// qf::core::sql::Query q(cc);
+	// if(cc.driverName().endsWith("SQLITE", Qt::CaseInsensitive))
+	// 	now = QStringLiteral("CURRENT_TIMESTAMP");
+	// bool ret = q.exec("UPDATE cards SET runId=" QF_IARG(run_id) ", runIdAssignTS=" + now + " WHERE id=" QF_IARG(card_id), !qf::core::Exception::Throw);
+	// return ret;
 }
 
 bool CardReaderPlugin::reloadTimesFromCard(int card_id, int run_id, bool in_transaction)
@@ -474,10 +535,26 @@ void CardReaderPlugin::assignCardToRun(int card_id, int run_id)
 
 void CardReaderPlugin::setStartTime(int relay_id, int leg, int start_time) {
 	qf::core::sql::Query q;
-	q.execThrow("UPDATE runs SET startTimeMs=" + QString::number(start_time)
-		   + " WHERE relayId=" + QString::number(relay_id)
+	q.execThrow("SELECT id FROM runs WHERE relayId=" + QString::number(relay_id)
 		   + " AND leg=" + QString::number(leg)
 		   + " AND COALESCE(startTimeMs, 0)=0");
+	// q.execThrow("UPDATE runs SET startTimeMs=" + QString::number(start_time)
+	// 	   + " WHERE relayId=" + QString::number(relay_id)
+	// 	   + " AND leg=" + QString::number(leg)
+	// 	   + " AND COALESCE(startTimeMs, 0)=0");
+	if (q.next()) {
+		try {
+			auto *app = qf::gui::framework::Application::instance();
+			QVariantMap rec {
+				{"startTimeMs", start_time},
+			};
+			auto run_id = q.value(0).toInt();
+			app->updateDbRecord("runs", run_id, rec);
+		}
+		catch (const std::exception &e) {
+			qfError() << "setStartTime(): Update runs error, query:" << e.what();
+		}
+	}
 }
 
 bool CardReaderPlugin::processCardToRunAssignment(int card_id, int run_id)

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
@@ -280,7 +280,7 @@ int CardReaderPlugin::saveCardToSql(const quickevent::core::si::ReadCard &read_c
 			{"runIdAssignError", read_card.runIdAssignError()},
 			{"data", qf::core::Utils::qvariantToJson(read_card.data())},
 		};
-		auto id = app->createDbRecord("cards", rec);
+		auto id = app->createDbRecord("cards", rec, this);
 		return id;
 	}
 	catch (const std::exception &e) {
@@ -333,7 +333,7 @@ int CardReaderPlugin::savePunchRecordToSql(const quickevent::core::si::PunchReco
 			{"timeMs", punch.timems()},
 			{"runTimeMs", punch.runtimems_isset()? punch.runtimems(): QVariant()},
 		};
-		auto id = app->createDbRecord("punches", rec);
+		auto id = app->createDbRecord("punches", rec, this);
 		return id;
 	}
 	catch (const std::exception &e) {
@@ -406,7 +406,7 @@ void CardReaderPlugin::updateCheckedCardValuesSql(int card_id, const quickevent:
 				{"notStart", false},
 				{"penaltyTimeMs", {}},
 			};
-			app->updateDbRecord("runs", run_id, rec);
+			app->updateDbRecord("runs", run_id, rec, this);
 		}
 		if (auto missing_codes = checked_card.missingCodes(); !missing_codes.isEmpty()) {
 			QStringList missing_str;
@@ -417,7 +417,7 @@ void CardReaderPlugin::updateCheckedCardValuesSql(int card_id, const quickevent:
 			QVariantMap rec {
 				{"runIdAssignError", missing_str.join(',')},
 			};
-			app->updateDbRecord("cards", card_id, rec);
+			app->updateDbRecord("cards", card_id, rec, this);
 		}
 	}
 	catch (const std::exception &e) {
@@ -463,7 +463,7 @@ bool CardReaderPlugin::saveCardAssignedRunnerIdSql(int card_id, int run_id)
 			{"runId", run_id},
 			{"runIdAssignTS", QDateTime::currentDateTime()},
 		};
-		app->updateDbRecord("cards", card_id, rec);
+		app->updateDbRecord("cards", card_id, rec, this);
 		return true;
 	}
 	catch (const std::exception &e) {
@@ -540,7 +540,7 @@ void CardReaderPlugin::setStartTime(int relay_id, int leg, int start_time) {
 				{"startTimeMs", start_time},
 			};
 			auto run_id = q.value(0).toInt();
-			app->updateDbRecord("runs", run_id, rec);
+			app->updateDbRecord("runs", run_id, rec, this);
 		}
 		catch (const std::exception &e) {
 			qfError() << "setStartTime(): Update runs error, query:" << e.what();

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
@@ -287,28 +287,6 @@ int CardReaderPlugin::saveCardToSql(const quickevent::core::si::ReadCard &read_c
 		qfError() << "Update runs error, query:" << e.what();
 		return 0;
 	}
-	// qf::core::sql::Query q;
-	// q.prepare(QStringLiteral("INSERT INTO cards (stationNumber, siId, checkTime, startTime, finishTime, punches, runId, stageId, readerConnectionId, runIdAssignError, data)"
-	// 						 " VALUES (:stationNumber, :siId, :checkTime, :startTime, :finishTime, :punches, :runId, :stageId, :readerConnectionId, :runIdAssignError, :data)")
-	// 		  , qf::core::Exception::Throw);
-	// q.bindValue(QStringLiteral(":stationNumber"), read_card.stationNumber());
-	// q.bindValue(QStringLiteral(":siId"), read_card.cardNumber());
-	// q.bindValue(QStringLiteral(":checkTime"), read_card.checkTime());
-	// q.bindValue(QStringLiteral(":startTime"), read_card.startTime());
-	// q.bindValue(QStringLiteral(":finishTime"), read_card.finishTime());
-	// q.bindValue(QStringLiteral(":punches"), '[' + punches.join(", ") + ']');
-	// q.bindValue(QStringLiteral(":runId"), read_card.runId());
-	// q.bindValue(QStringLiteral(":stageId"), currentStageId());
-	// q.bindValue(QStringLiteral(":readerConnectionId"), qf::core::sql::Connection::defaultConnection().connectionId());
-	// q.bindValue(QStringLiteral(":runIdAssignError"), read_card.runIdAssignError());
-	// q.bindValue(QStringLiteral(":data"), qf::core::Utils::qvariantToJson(read_card.data()));
-	// if(q.exec()) {
-	// 	ret = q.lastInsertId().toInt();
-	// }
-	// else {
-	// 	qfError() << tr("Save card ERROR: %1").arg(q.lastErrorText());
-	// }
-	// return ret;
 }
 
 int CardReaderPlugin::savePunchRecordToSql(const quickevent::core::si::PunchRecord &punch_record)
@@ -383,7 +361,7 @@ int CardReaderPlugin::savePunchRecordToSql(const quickevent::core::si::PunchReco
 	// return ret;
 }
 
-void CardReaderPlugin::updateCheckedCardValuesSql(const quickevent::core::si::CheckedCard &checked_card) noexcept(false)
+void CardReaderPlugin::updateCheckedCardValuesSql(int card_id, const quickevent::core::si::CheckedCard &checked_card)
 {
 	QF_TIME_SCOPE("updateCheckedCardValuesSql()");
 	int run_id = checked_card.runId();
@@ -418,16 +396,29 @@ void CardReaderPlugin::updateCheckedCardValuesSql(const quickevent::core::si::Ch
 
 	try {
 		auto *app = qf::gui::framework::Application::instance();
-		QVariantMap rec {
-			{"checkTimeMs", checked_card.checkTimeMs()},
-			{"timeMs", checked_card.timeMs()},
-			{"finishTimeMs", checked_card.finishTimeMs()},
-			{"misPunch", checked_card.isMisPunch()},
-			{"badCheck", checked_card.isBadCheck()},
-			{"notStart", false},
-			{"penaltyTimeMs", {}},
-		};
-		app->updateDbRecord("runs", run_id, rec);
+		{
+			QVariantMap rec {
+				{"checkTimeMs", checked_card.checkTimeMs()},
+				{"timeMs", checked_card.timeMs()},
+				{"finishTimeMs", checked_card.finishTimeMs()},
+				{"misPunch", checked_card.isMisPunch()},
+				{"badCheck", checked_card.isBadCheck()},
+				{"notStart", false},
+				{"penaltyTimeMs", {}},
+			};
+			app->updateDbRecord("runs", run_id, rec);
+		}
+		if (auto missing_codes = checked_card.missingCodes(); !missing_codes.isEmpty()) {
+			QStringList missing_str;
+			for (const auto &vl : missing_codes) {
+				auto vll = vl.toList();
+				missing_str << QStringLiteral("%1-%2").arg(vll.value(0).toInt()).arg(vll.value(1).toInt());
+			}
+			QVariantMap rec {
+				{"runIdAssignError", tr("Missing codes: %1").arg(missing_str.join(','))},
+			};
+			app->updateDbRecord("cards", card_id, rec);
+		}
 	}
 	catch (const std::exception &e) {
 		qfError() << "Update runs error, query:" << e.what();
@@ -583,9 +574,9 @@ bool CardReaderPlugin::processCardToRunAssignment(int card_id, int run_id)
 				}
 			}
 		}
-		quickevent::core::si::CheckedCard checked_card = checkCard(card_id, run_id);
+		auto checked_card = checkCard(card_id, run_id);
 		//qfDebug() << checked_card.toString();
-		updateCheckedCardValuesSql(checked_card);
+		updateCheckedCardValuesSql(card_id, checked_card);
 		getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_CARD_PROCESSED_AND_ASSIGNED, checked_card, true);
 
 		q.execThrow("SELECT id, startTimeMs, finishTimeMs FROM runs"
@@ -620,8 +611,8 @@ bool CardReaderPlugin::processCardToRunAssignment(int card_id, int run_id)
 		}
 	}
 	else {
-		quickevent::core::si::CheckedCard checked_card = checkCard(card_id, run_id);
-		updateCheckedCardValuesSql(checked_card);
+		auto checked_card = checkCard(card_id, run_id);
+		updateCheckedCardValuesSql(card_id, checked_card);
 		getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_CARD_PROCESSED_AND_ASSIGNED, checked_card, true);
 	}
 	return true;

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.h
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.h
@@ -54,7 +54,7 @@ private:
 
 	void updateCardToRunAssignmentInPunches(int stage_id, int card_id, int run_id);
 	bool saveCardAssignedRunnerIdSql(int card_id, int run_id);
-	void updateCheckedCardValuesSql(const quickevent::core::si::CheckedCard &checked_card) noexcept(false);
+        void updateCheckedCardValuesSql(int card_id, const quickevent::core::si::CheckedCard &checked_card) ;
 	void setStartTime(int relay_id, int leg, int start_time);
 private:
 	QList<CardChecker*> m_cardCheckers;

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.cpp
@@ -46,7 +46,6 @@
 #include <plugins/Receipts/src/receiptsplugin.h>
 #include <plugins/Event/src/eventplugin.h>
 #include <plugins/Runs/src/findrunnerwidget.h>
-// #include <plugins/Competitors/src/competitorsplugin.h>
 #include <plugins/Runs/src/runflagsdialog.h>
 #include <plugins/Runs/src/runsplugin.h>
 
@@ -69,7 +68,6 @@ using qf::gui::framework::getPlugin;
 using Event::EventPlugin;
 using CardReader::CardReaderPlugin;
 using Receipts::ReceiptsPlugin;
-// using Competitors::CompetitorsPlugin;
 using Runs::RunsPlugin;
 
 namespace {
@@ -261,6 +259,8 @@ CardReaderWidget::CardReaderWidget(QWidget *parent)
 			}
 		}
 	}, Qt::QueuedConnection);
+
+	connect(qf::gui::framework::Application::instance(), &qf::gui::framework::Application::dbRecChng, this, &CardReaderWidget::onDbRecChng, Qt::QueuedConnection);
 }
 
 CardReaderWidget::~CardReaderWidget()
@@ -509,6 +509,20 @@ void CardReaderWidget::reload()
 	qfDebug() << qb.toString();
 	m_cardsModel->setQueryBuilder(qb, false);
 	m_cardsModel->reload();
+}
+
+void CardReaderWidget::onDbRecChng(const qf::core::sql::RecChng &recchng)
+{
+	if(isVisible()) {
+		if (recchng.table == "cards" && recchng.op == qf::core::sql::RecOp::Update) {
+			for (int i = 0; i < m_cardsModel->rowCount(); ++i) {
+				if (m_cardsModel->value(i, "cards.id").toInt() == recchng.id) {
+					m_cardsModel->reloadRow(i);
+					break;
+				}
+			}
+		}
+	}
 }
 
 void CardReaderWidget::onDbEventNotify(const QString &domain, int connection_id, const QVariant &data)

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.cpp
@@ -797,19 +797,38 @@ void CardReaderWidget::assignRunnerToSelectedCard()
 								   "is currently flagged \"not running\" for this stage (race).\n"
 								   "If you continue, this flag will be removed"),
 								QMessageBox::Ok | QMessageBox::Cancel);
-				if (ret == QMessageBox::Cancel)
+				if (ret == QMessageBox::Cancel) {
 					return;
-				QString qs = "UPDATE runs SET isRunning=true WHERE competitorId=" QF_IARG(competitor_id) " AND stageId=" QF_IARG(stage_id);
-				q.execThrow(qs);
+				}
+				auto *app = qf::gui::framework::Application::instance();
+				QVariantMap rec {
+					{"isRunning", true},
+				};
+				app->updateDbRecord("runs", run_id, rec);
+				// QString qs = "UPDATE runs SET isRunning=true WHERE competitorId=" QF_IARG(competitor_id) " AND stageId=" QF_IARG(stage_id);
+				// q.execThrow(qs);
 			}
 		}
 		{
 			getPlugin<CardReaderPlugin>()->assignCardToRun(card_id, run_id);
-			QString qs = "UPDATE runs SET siId=" QF_IARG(si_id) " WHERE competitorId=" QF_IARG(competitor_id) " AND stageId=" QF_IARG(stage_id);
-			if(values.value(Runs::FindRunnerWidget::UseSIInNextStages).toBool()) {
-				qs = "UPDATE runs SET siId=" QF_IARG(si_id) " WHERE competitorId=" QF_IARG(competitor_id) " AND stageId>=" QF_IARG(stage_id);
+			q.execThrow("SELECT id FROM runs WHERE competitorId=" QF_IARG(competitor_id)
+						" AND stageId>=" QF_IARG(stage_id)
+						" ORDER BY stageId");
+			int n = 0;
+			auto *app = qf::gui::framework::Application::instance();
+			bool use_si_in_next_stages = values.value(Runs::FindRunnerWidget::UseSIInNextStages).toBool();
+			while (q.next()) {
+				QVariantMap rec { {"siId", si_id}, };
+				auto run_id = q.value(0).toInt();
+				if (n++ == 0 || use_si_in_next_stages) {
+					app->updateDbRecord("runs", run_id, rec);
+				}
 			}
-			q.execThrow(qs);
+			// QString qs = "UPDATE runs SET siId=" QF_IARG(si_id) " WHERE competitorId=" QF_IARG(competitor_id) " AND stageId=" QF_IARG(stage_id);
+			// if(values.value(Runs::FindRunnerWidget::UseSIInNextStages).toBool()) {
+			// 	qs = "UPDATE runs SET siId=" QF_IARG(si_id) " WHERE competitorId=" QF_IARG(competitor_id) " AND stageId>=" QF_IARG(stage_id);
+			// }
+			// q.execThrow(qs);
 		}
 
 		this->ui->tblCards->reloadRow();

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.cpp
@@ -260,7 +260,7 @@ CardReaderWidget::CardReaderWidget(QWidget *parent)
 		}
 	}, Qt::QueuedConnection);
 
-	connect(qf::gui::framework::Application::instance(), &qf::gui::framework::Application::dbRecChng, this, &CardReaderWidget::onDbRecChng, Qt::QueuedConnection);
+	connect(qf::gui::framework::Application::instance(), &qf::gui::framework::Application::qxRecChng, this, &CardReaderWidget::onQxRecChng, Qt::QueuedConnection);
 }
 
 CardReaderWidget::~CardReaderWidget()
@@ -511,7 +511,7 @@ void CardReaderWidget::reload()
 	m_cardsModel->reload();
 }
 
-void CardReaderWidget::onDbRecChng(const qf::core::sql::RecChng &recchng)
+void CardReaderWidget::onQxRecChng(const qf::core::sql::QxRecChng &recchng)
 {
 	if(isVisible()) {
 		if (recchng.table == "cards" && recchng.op == qf::core::sql::RecOp::Update) {
@@ -818,7 +818,7 @@ void CardReaderWidget::assignRunnerToSelectedCard()
 				QVariantMap rec {
 					{"isRunning", true},
 				};
-				app->updateDbRecord("runs", run_id, rec);
+				app->updateDbRecord("runs", run_id, rec, this);
 				// QString qs = "UPDATE runs SET isRunning=true WHERE competitorId=" QF_IARG(competitor_id) " AND stageId=" QF_IARG(stage_id);
 				// q.execThrow(qs);
 			}
@@ -835,7 +835,7 @@ void CardReaderWidget::assignRunnerToSelectedCard()
 				QVariantMap rec { {"siId", si_id}, };
 				auto run_id = q.value(0).toInt();
 				if (n++ == 0 || use_si_in_next_stages) {
-					app->updateDbRecord("runs", run_id, rec);
+					app->updateDbRecord("runs", run_id, rec, this);
 				}
 			}
 			// QString qs = "UPDATE runs SET siId=" QF_IARG(si_id) " WHERE competitorId=" QF_IARG(competitor_id) " AND stageId=" QF_IARG(stage_id);

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.h
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.h
@@ -17,13 +17,13 @@ namespace Ui {
 }
 
 namespace quickevent::gui::og { class SqlTableModel; }
+namespace qf::core::sql { struct RecChng; }
 
-namespace qf {
-namespace gui {
+namespace qf::gui {
 class Action;
 namespace framework { class PartWidget; class Plugin; }
 }
-}
+
 
 namespace siut { class DeviceDriver; class CommPort; class SICard; class SIPunch; }
 
@@ -67,8 +67,9 @@ public:
 	Q_SLOT void reset();
 	Q_SLOT void reload();
 
+private:
+	void onDbRecChng(const qf::core::sql::RecChng &recchng);
 	void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
-private slots:
 	void appendLog(NecroLog::Level level, const QString &msg);
 	void processDriverInfo(NecroLog::Level level, const QString &msg);
 	void logDriverRawData(const QByteArray &data);

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.h
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.h
@@ -17,7 +17,7 @@ namespace Ui {
 }
 
 namespace quickevent::gui::og { class SqlTableModel; }
-namespace qf::core::sql { struct RecChng; }
+namespace qf::core::sql { struct QxRecChng; }
 
 namespace qf::gui {
 class Action;
@@ -68,7 +68,7 @@ public:
 	Q_SLOT void reload();
 
 private:
-	void onDbRecChng(const qf::core::sql::RecChng &recchng);
+	void onQxRecChng(const qf::core::sql::QxRecChng &recchng);
 	void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
 	void appendLog(NecroLog::Level level, const QString &msg);
 	void processDriverInfo(NecroLog::Level level, const QString &msg);

--- a/quickevent/app/quickevent/plugins/Competitors/src/competitordocument.cpp
+++ b/quickevent/app/quickevent/plugins/Competitors/src/competitordocument.cpp
@@ -92,7 +92,7 @@ bool CompetitorDocument::saveData()
 					getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_RUN_CHANGED, QVariantList {run_id, rec});
 					// new update API
 					auto *app = qf::gui::framework::Application::instance();
-					app->emitDbRecInserted( "runs", run_id, rec);
+					app->emitDbRecInserted( "runs", run_id, rec, this);
 				}
 			}
 		}
@@ -103,7 +103,7 @@ bool CompetitorDocument::saveData()
 				auto *app = qf::gui::framework::Application::instance();
 				QVariantMap rec { {"siId", siid()}, };
 				for (const auto &[run_id, _] : old_records.asKeyValueRange()) {
-					app->updateDbRecord("runs", run_id, rec);
+					app->updateDbRecord("runs", run_id, rec, this);
 				}
 				// int competitor_id = dataId().toInt();
 				// qf::core::sql::Query q(sqlModel()->connectionName());
@@ -171,7 +171,7 @@ bool CompetitorDocument::dropData()
 				getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_RUN_CHANGED, QVariantList {run_id, {}});
 				// new update API
 				auto *app = qf::gui::framework::Application::instance();
-				app->emitDbRecDeleted("runs", run_id);
+				app->emitDbRecDeleted("runs", run_id, this);
 			}
 		}
 	}

--- a/quickevent/app/quickevent/plugins/Competitors/src/competitordocument.cpp
+++ b/quickevent/app/quickevent/plugins/Competitors/src/competitordocument.cpp
@@ -100,12 +100,17 @@ bool CompetitorDocument::saveData()
 			competitor_id = dataId().toInt();
 			if(siid_dirty) {
 				qfDebug() << "updating SIID in run tables";
-				int competitor_id = dataId().toInt();
-				qf::core::sql::Query q(sqlModel()->connectionName());
-				q.prepare("UPDATE runs SET siId=:siId WHERE competitorId=:competitorId", qf::core::Exception::Throw);
-				q.bindValue(":competitorId", competitor_id);
-				q.bindValue(":siId", siid());
-				q.exec(qf::core::Exception::Throw);
+				auto *app = qf::gui::framework::Application::instance();
+				QVariantMap rec { {"siId", siid()}, };
+				for (const auto &[run_id, _] : old_records.asKeyValueRange()) {
+					app->updateDbRecord("runs", run_id, rec);
+				}
+				// int competitor_id = dataId().toInt();
+				// qf::core::sql::Query q(sqlModel()->connectionName());
+				// q.prepare("UPDATE runs SET siId=:siId WHERE competitorId=:competitorId", qf::core::Exception::Throw);
+				// q.bindValue(":competitorId", competitor_id);
+				// q.bindValue(":siId", siid());
+				// q.exec(qf::core::Exception::Throw);
 			}
 			if(m_isEmitDbEventsOnSave) {
 				if(class_dirty) {
@@ -116,10 +121,6 @@ bool CompetitorDocument::saveData()
 					auto diff = qf::core::sql::recordDiff(old_record, record);
 					if (!diff.isEmpty()) {
 						getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_RUN_CHANGED, QVariantList {run_id, diff});
-
-						// new update API
-						auto *app = qf::gui::framework::Application::instance();
-						app->emitDbRecUpdated( "runs", run_id, diff);
 					}
 				}
 			}

--- a/quickevent/app/quickevent/plugins/Competitors/src/competitordocument.cpp
+++ b/quickevent/app/quickevent/plugins/Competitors/src/competitordocument.cpp
@@ -5,6 +5,7 @@
 
 #include <qf/gui/framework/mainwindow.h>
 #include <qf/gui/framework/plugin.h>
+#include <qf/gui/framework/application.h>
 
 #include <qf/core/sql/connection.h>
 #include <qf/core/sql/query.h>
@@ -81,13 +82,17 @@ bool CompetitorDocument::saveData()
 				if(siid_dirty)
 					q.bindValue(":siId", siid());
 				q.exec(qf::core::Exception::Throw);
-				m_runsIds << q.lastInsertId().toInt();
+				auto run_id = q.lastInsertId().toInt();
+				m_runsIds << run_id;
 			}
 			if(m_isEmitDbEventsOnSave) {
 				getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_COMPETITOR_COUNTS_CHANGED);
 				for (auto run_id : m_runsIds) {
 					auto rec = runs_plugin->runsRecord(run_id);
 					getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_RUN_CHANGED, QVariantList {run_id, rec});
+					// new update API
+					auto *app = qf::gui::framework::Application::instance();
+					app->emitDbRecInserted( "runs", run_id, rec);
 				}
 			}
 		}
@@ -111,6 +116,10 @@ bool CompetitorDocument::saveData()
 					auto diff = qf::core::sql::recordDiff(old_record, record);
 					if (!diff.isEmpty()) {
 						getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_RUN_CHANGED, QVariantList {run_id, diff});
+
+						// new update API
+						auto *app = qf::gui::framework::Application::instance();
+						app->emitDbRecUpdated( "runs", run_id, diff);
 					}
 				}
 			}
@@ -123,11 +132,11 @@ bool CompetitorDocument::saveData()
 		if (m_isEmitDbEventsOnSave)
 		{
 			if (old_mode == DataDocument::ModeInsert)
-			{				
+			{
 				getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_COMPETITOR_ADDED, competitor_id);
 			}
 			else if (old_mode == DataDocument::ModeEdit)
-			{				
+			{
 				getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_COMPETITOR_EDITED, competitor_id);
 			}
 		}
@@ -159,6 +168,9 @@ bool CompetitorDocument::dropData()
 			getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_COMPETITOR_COUNTS_CHANGED);
 			for (auto run_id : run_ids) {
 				getPlugin<EventPlugin>()->emitDbEvent(Event::EventPlugin::DBEVENT_RUN_CHANGED, QVariantList {run_id, {}});
+				// new update API
+				auto *app = qf::gui::framework::Application::instance();
+				app->emitDbRecDeleted("runs", run_id);
 			}
 		}
 	}

--- a/quickevent/app/quickevent/plugins/Competitors/src/competitorwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Competitors/src/competitorwidget.cpp
@@ -446,20 +446,20 @@ QList<int> CompetitorWidget::possibleStartTimesMs(int run_id)
 		if (lo == up || stime == start_time) {
 			// stime does not exist or it is my current start_time, should be inserted before up
 			// check next club
-			qfInfo() << "free stime:" << quickevent::core::og::TimeMs(stime).toString();
+			// qfInfo() << "free stime:" << quickevent::core::og::TimeMs(stime).toString();
 			if (up != runs.end()) {
 				qfInfo() << "next club:" << up->club;
 				if (up->club == club_abbr && (up->start_time - stime) <= start_interval_ms) {
-					qfInfo() << "same next club:" << club_abbr;
+					// qfInfo() << "same next club:" << club_abbr;
 					continue;
 				}
 			}
 			// check prev club
 			if (up != runs.begin()) {
 				up--;
-				qfInfo() << "prev club:" << up->club;
+				// qfInfo() << "prev club:" << up->club;
 				if (up->club == club_abbr && (stime - up->start_time) <= start_interval_ms) {
-					qfInfo() << "same prev club:" << club_abbr;
+					// qfInfo() << "same prev club:" << club_abbr;
 					continue;
 				}
 			}
@@ -468,19 +468,6 @@ QList<int> CompetitorWidget::possibleStartTimesMs(int run_id)
 	}
 	return ret;
 }
-
-// void CompetitorWidget::showRunsTable(int stage_id)
-// {
-// 	if(!saveData())
-// 		return;
-
-// 	qf::gui::model::DataDocument*doc = dataController()->document();
-// 	int competitor_id = doc->value("competitors.id").toInt();
-// 	int class_id = ui->cbxClass->currentData().toInt();
-// 	QString sort_col = QStringLiteral("runs.startTimeMs");
-// 	getPlugin<RunsPlugin>()->showRunsTable(stage_id, class_id, false, sort_col, competitor_id);
-// 	loadRunsTable();
-// }
 
 void CompetitorWidget::onRegistrationSelected(const QVariantMap &values)
 {

--- a/quickevent/app/quickevent/plugins/Event/src/eventplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/eventplugin.cpp
@@ -141,6 +141,7 @@ EventPlugin::EventPlugin(QObject *parent)
 		setEventOpen(!event_name.isEmpty());
 	});
 	connect(this, &Event::EventPlugin::dbEventNotify, this, &Event::EventPlugin::onDbEventNotify, Qt::QueuedConnection);
+	connect(qf::gui::framework::Application::instance(), &qf::gui::framework::Application::qxRecChng, this, &EventPlugin::onRecChng);
 }
 
 void EventPlugin::initEventConfig()
@@ -480,11 +481,11 @@ void EventPlugin::emitDbEvent(const QString &domain, const QVariant &data, bool 
 	if(payload_str.length() > 4000) {
 		int len = payload_str.toUtf8().length();
 		if(len > 8000) {
-			qfInfo() << payload_str;
 			qfError() << "Payload of size" << len << "is too long. Max Postgres payload length is 8000 bytes.";
 			return;
 		}
 	}
+	qfMessage() << "to postgres:" << payload_str;
 	payload_str = qf::core::sql::Connection::escapeJsonForSql(payload_str);
 	qf::core::sql::Connection conn = qf::core::sql::Connection::forName();
 	QString qs = QString("NOTIFY ") + DBEVENT_NOTIFY_NAME + ", '" + payload_str + "'";
@@ -608,7 +609,17 @@ void EventPlugin::onDbEvent(const QString &name, QSqlDriver::NotificationSource 
 			}
 			if(event_name == eventName()) {
 				QVariant data = dbpl.data();
-				qfDebug() << "emitting domain:" << domain << "data:" << data;
+				if (dbpl.domain() == DBEVENT_QX_RECCHNG) {
+					qfMessage() << "from postgres:" << data;
+					auto recchng = qf::core::sql::QxRecChng::fromVariantMap(data.toMap());
+					if (recchng.issuer == qf::gui::framework::Application::uuidString()) {
+						qfWarning() << "RecChng loopback detected, issuer:" << recchng.issuer;
+						return;
+					}
+					qf::gui::framework::Application::instance()->emitQxRecChng(recchng, this);
+					return;
+				}
+				qfMessage() << "emitting domain:" << domain << "data:" << data;
 				emit dbEventNotify(domain, dbpl.connectionId(), data);
 			}
 		}
@@ -1379,6 +1390,14 @@ void EventPlugin::onDbEventNotify(const QString &domain, int connection_id, cons
 	else if(domain == QLatin1String(Event::EventPlugin::DBEVENT_REGISTRATIONS_IMPORTED)) {
 		reloadRegistrationsModel();
 	}
+}
+
+void EventPlugin::onRecChng(const qf::core::sql::QxRecChng &recchng)
+{
+	if (recchng.issuer != qf::gui::framework::Application::uuidString()) {
+		return;
+	}
+	emitDbEvent(DBEVENT_QX_RECCHNG, recchng.toVariantMap(), false);
 }
 
 void EventPlugin::reloadRegistrationsModel()

--- a/quickevent/app/quickevent/plugins/Event/src/eventplugin.h
+++ b/quickevent/app/quickevent/plugins/Event/src/eventplugin.h
@@ -12,7 +12,7 @@
 #include <QVariantMap>
 #include <QSqlDriver>
 
-namespace qf::core::sql { class Query; class Connection; }
+namespace qf::core::sql { class Query; class Connection; struct QxRecChng; }
 namespace qf::gui { class Action; }
 namespace qf::gui::framework { class DockWidget; }
 namespace qf::gui::model { class SqlTableModel; }
@@ -61,6 +61,7 @@ public:
 	static constexpr auto DBEVENT_REGISTRATIONS_IMPORTED = "registrationsImported";
 	static constexpr auto DBEVENT_STAGE_START_CHANGED = "stageStartChanged";
 	static constexpr auto DBEVENT_QX_CHANGE_RECEIVED = "qxChangeReceived";
+	static constexpr auto DBEVENT_QX_RECCHNG = "qxRecChng";
 
 	Q_INVOKABLE void initEventConfig();
 	Event::EventConfig* eventConfig(bool reload = false);
@@ -129,14 +130,16 @@ private:
 	QStringList existingSqlEventNames() const;
 	QStringList existingFileEventNames(const QString &dir = QString()) const;
 
-	Q_SLOT void onEventOpened();
-	Q_SLOT void connectToSqlServer();
-	Q_SLOT void loadCurrentStageId();
-	Q_SLOT void saveCurrentStageId(int current_stage);
-	Q_SLOT void editStage();
-	Q_SLOT void onDbEvent(const QString & name, QSqlDriver::NotificationSource source, const QVariant & payload);
+	void onEventOpened();
+	void connectToSqlServer();
+	void loadCurrentStageId();
+	void saveCurrentStageId(int current_stage);
+	void editStage();
+	void onDbEvent(const QString & name, QSqlDriver::NotificationSource source, const QVariant & payload);
 
 	void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
+
+	void onRecChng(const qf::core::sql::QxRecChng &recchng);
 
 	void onRegistrationsDockVisibleChanged(bool on = true);
 

--- a/quickevent/app/quickevent/plugins/Oris/src/txtimporter.cpp
+++ b/quickevent/app/quickevent/plugins/Oris/src/txtimporter.cpp
@@ -222,8 +222,9 @@ void TxtImporter::importParsedCsv(const QList<QVariantList> &csv)
 		QString reg = row.value(ColRegistration).toString();
 		QString class_name = row.value(ColClassName).toString();
 		int class_id = classes_map.value(class_name);
-		if(class_id == 0)
+		if(class_id == 0) {
 			QF_EXCEPTION(tr("Undefined class name: '%1'").arg(class_name));
+		}
 		//fwk->showProgress("Importing: " + reg_no + ' ' + last_name + ' ' + first_name, items_processed, items_count);
 		//	qfWarning() << tr("%1 %2 %3 SI: %4 is duplicit!").arg(reg_no).arg(last_name).arg(first_name).arg(siid);
 		doc.setValue("classId", class_id);

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
@@ -6,7 +6,9 @@
 
 #include <qf/gui/log.h>
 #include <qf/gui/framework/mainwindow.h>
+#include <qf/gui/framework/application.h>
 
+#include <qf/core/sql/qxrecchng.h>
 #include <qf/core/sql/query.h>
 #include <qf/core/sql/connection.h>
 #include <qf/core/sql/transaction.h>
@@ -48,6 +50,7 @@ RunsTableModel::RunsTableModel(QObject *parent)
 	setColumn(col_competitors_note, ColumnDefinition("competitors.note", tr("Note")));
 
 	connect(this, &RunsTableModel::dataChanged, this, &RunsTableModel::onDataChanged, Qt::QueuedConnection);
+	connect(qf::gui::framework::Application::instance(), &qf::gui::framework::Application::qxRecChng, this, &RunsTableModel::onQxRecChng, Qt::QueuedConnection);
 }
 
 Qt::ItemFlags RunsTableModel::flags(const QModelIndex &index) const
@@ -331,6 +334,11 @@ void RunsTableModel::onDataChanged(const QModelIndex &top_left, const QModelInde
 	Q_UNUSED(roles)
 	if(top_left.column() <= RunsTableModel::col_runs_siId && bottom_right.column() >= RunsTableModel::col_runs_siId)
 		emit runnerSiIdEdited();
+}
+
+void RunsTableModel::onQxRecChng(const qf::core::sql::QxRecChng &recchng, QObject *source)
+{
+	handleQxRecChng(recchng, source);
 }
 
 bool RunsTableModel::postRow(int row_no, bool throw_exc)

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.h
@@ -3,6 +3,8 @@
 
 #include <quickevent/gui/og/sqltablemodel.h>
 
+namespace qf::core::sql { struct QxRecChng; }
+
 class RunsTableModel : public quickevent::gui::og::SqlTableModel
 {
 	Q_OBJECT
@@ -62,6 +64,7 @@ public:
 	Q_SIGNAL void badDataInput(const QString &message);
 private:
 	void onDataChanged(const QModelIndex &top_left, const QModelIndex &bottom_right, const QVector<int> &roles);
+	void onQxRecChng(const qf::core::sql::QxRecChng &recchng, QObject *source);
 };
 
 #endif // RUNSTABLEMODEL_H

--- a/quickevent/app/quickevent/plugins/Speaker/src/codeclassresultswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Speaker/src/codeclassresultswidget.cpp
@@ -114,8 +114,8 @@ void CodeClassResultsWidget::onPunchReceived(const quickevent::core::si::PunchRe
 void CodeClassResultsWidget::reset(int class_id, int code, int pin_to_code)
 {
 	m_pinnedToCode = pin_to_code;
-	ui->lstClass->disconnect();
-	ui->lstCode->disconnect();
+	disconnect(ui->lstClass, QOverload<int>::of(&QComboBox::currentIndexChanged), nullptr, nullptr);
+	disconnect(ui->lstCode, QOverload<int>::of(&QComboBox::currentIndexChanged), nullptr, nullptr);
 	ui->lstClass->clear();
 	{
 		qf::core::sql::Query q;

--- a/quickevent/app/quickevent/src/main.cpp
+++ b/quickevent/app/quickevent/src/main.cpp
@@ -189,6 +189,20 @@ int main(int argc, char *argv[])
 	main_window.show();
 	emit main_window.applicationLaunched();
 
+	// QObject::connect(&app, &Application::dbRecChng, &app, [](const qf::core::sql::RecChng &recchng) {
+	// 	auto dump_map = [](const QVariantMap &m) {
+	// 		QStringList rows;
+	// 		for (const auto &[k, v] : m.asKeyValueRange()) {
+	// 			rows << QStringLiteral("%1 -> %2").arg(k).arg(v.toString());
+	// 		}
+	// 		return rows.join('\n');
+	// 	};
+	// 	qfInfo() << "REC-CHNG table:" << recchng.table
+	// 			 << "op:" << qf::core::sql::RecChng::recopToString(recchng.op)
+	// 			 << "id:" << recchng.id
+	// 			 << "record:" << dump_map(recchng.record);
+	// });
+
 	int ret = Application::exec();
 
 	return ret;

--- a/quickevent/app/quickevent/src/main.cpp
+++ b/quickevent/app/quickevent/src/main.cpp
@@ -189,19 +189,19 @@ int main(int argc, char *argv[])
 	main_window.show();
 	emit main_window.applicationLaunched();
 
-	// QObject::connect(&app, &Application::dbRecChng, &app, [](const qf::core::sql::RecChng &recchng) {
-	// 	auto dump_map = [](const QVariantMap &m) {
-	// 		QStringList rows;
-	// 		for (const auto &[k, v] : m.asKeyValueRange()) {
-	// 			rows << QStringLiteral("%1 -> %2").arg(k).arg(v.toString());
-	// 		}
-	// 		return rows.join('\n');
-	// 	};
-	// 	qfInfo() << "REC-CHNG table:" << recchng.table
-	// 			 << "op:" << qf::core::sql::RecChng::recopToString(recchng.op)
-	// 			 << "id:" << recchng.id
-	// 			 << "record:" << dump_map(recchng.record);
-	// });
+	QObject::connect(&app, &Application::qxRecChng, &app, [](const qf::core::sql::QxRecChng &recchng) {
+		auto dump_map = [](const QVariantMap &m) {
+			QStringList rows;
+			for (const auto &[k, v] : m.asKeyValueRange()) {
+				rows << QStringLiteral("%1 -> %2").arg(k).arg(v.toString());
+			}
+			return rows.join('\n');
+		};
+		qfInfo() << "REC-CHNG table:" << recchng.table
+				 << "op:" << qf::core::sql::QxRecChng::recopToString(recchng.op)
+				 << "id:" << recchng.id
+				 << "record:" << dump_map(recchng.record);
+	});
 
 	int ret = Application::exec();
 


### PR DESCRIPTION
I'm not able to finish https://github.com/Quick-Box/quickevent/pull/1069 in near future, but DB cange API is finished already. 

@lukaskett please check if this API fits also needs of O-feed

Usage example:
```c++
QObject::connect(&app, &Application::dbRecChng, &app, [](const qf::core::sql::RecChng &recchng) {
	auto dump_map = [](const QVariantMap &m) {
		QStringList rows;
		for (const auto &[k, v] : m.asKeyValueRange()) {
			rows << QStringLiteral("%1 -> %2").arg(k).arg(v.toString());
		}
		return rows.join('\n');
	};
	qfInfo() << "REC-CHNG table:" << recchng.table
			 << "op:" << qf::core::sql::RecChng::recopToString(recchng.op)
			 << "id:" << recchng.id
			 << "record:" << dump_map(recchng.record);
});
```