### PR TITLE
Fix clang-tidy linter to handle empty file arrays correctly

### DIFF
--- a/.github/actions/run-linter/action.yml
+++ b/.github/actions/run-linter/action.yml
@@ -49,4 +49,10 @@ runs:
         fi
         echo "Changed files:"
         printf '%s\n' "${CHANGED_FILES[@]}"
+        # Filter out any empty strings that may have been added to the array
+        CHANGED_FILES=("${CHANGED_FILES[@]}" | grep -v '^$')
+        if [[ "${#CHANGED_FILES[@]}" -eq 0 ]]; then
+          echo "No changed cpp files after filtering."
+          exit 0
+        fi
         printf '%s\n' "${CHANGED_FILES[@]}" | parallel --verbose --jobs "$(nproc)" --plus _=[{#}/{##}] ${{ inputs.lint_program_with_args }} {}

--- a/.github/actions/run-linter/action.yml
+++ b/.github/actions/run-linter/action.yml
@@ -50,7 +50,7 @@ runs:
         echo "Changed files:"
         printf '%s\n' "${CHANGED_FILES[@]}"
         # Filter out any empty strings that may have been added to the array
-        CHANGED_FILES=("${CHANGED_FILES[@]}" | grep -v '^$')
+        readarray -t CHANGED_FILES < <(printf '%s\n' "${CHANGED_FILES[@]}" | grep -v '^$')
         if [[ "${#CHANGED_FILES[@]}" -eq 0 ]]; then
           echo "No changed cpp files after filtering."
           exit 0


### PR DESCRIPTION
When all changed C++ files are excluded by the exclude_files_pattern, the linter was attempting to run clang-tidy with an empty string argument, causing a process error.

Changes:
- Add a second check after filtering to ensure no empty strings remain in the array
- Exit cleanly if no files are found after filtering
- This prevents passing empty strings to the linter command

Fixes the failing lint job when only excluded files are changed.