### PR TITLE
fix: handle a list of available start names based on the active stage

### DIFF
--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
@@ -42,20 +42,7 @@ ReportOptionsDialog::ReportOptionsDialog(QWidget *parent)
 	ui->grpRelayOptions->setVisible(false);
 	ui->btRegExp->setEnabled(QSqlDatabase::database().driverName().endsWith(QLatin1String("PSQL"), Qt::CaseInsensitive));
 
-	{
-		// fill start numbers from courses
-		// TODO: will work for single stage events only
-		ui->cbxStartNumber->addItem(QString("All"), 0);
-		QString query_str = "SELECT code FROM codes ORDER BY id";
-		qf::core::sql::Query q;
-		q.exec(query_str, qf::core::Exception::Throw);
-		while (q.next()) {
-			auto code = q.value(0).toInt();
-			if(auto n = core::CodeDef::codeToStartNumber(code); n.has_value()) {
-				ui->cbxStartNumber->addItem(QString("Start %1").arg(n.value()), n.value());
-			}
-		}
-	}
+	setCurrentStageId(0);
 	connect(ui->btSaveAsDefault, &QPushButton::clicked, this, [this]() {
 		savePersistentSettings();
 	});
@@ -387,6 +374,29 @@ void ReportOptionsDialog::setStartListForRelays()
 	ui->chkStartOpts_PrintStartNumbers->setVisible(false);
 	ui->lblStartNumber->setVisible(false);
 	ui->cbxStartNumber->setVisible(false);
+}
+
+void ReportOptionsDialog::setCurrentStageId(int stageId)
+{
+	ui->cbxStartNumber->clear();
+	ui->cbxStartNumber->addItem(QString("All"), 0);
+	QString query_str;
+	if (stageId > 0) {
+		query_str = QString("SELECT DISTINCT codes.code FROM codes, coursecodes, classdefs"
+							" WHERE coursecodes.codeId = codes.id AND classdefs.courseId = coursecodes.courseId"
+							" AND classdefs.stageId = %1"
+							" ORDER BY codes.code").arg(stageId);
+	} else {
+		query_str = QStringLiteral("SELECT code FROM codes ORDER BY id");
+	}
+	qf::core::sql::Query q;
+	q.exec(query_str, qf::core::Exception::Throw);
+	while (q.next()) {
+		auto code = q.value(0).toInt();
+		if(auto n = core::CodeDef::codeToStartNumber(code); n.has_value()) {
+			ui->cbxStartNumber->addItem(QString("Start %1").arg(n.value()), n.value());
+		}
+	}
 }
 
 

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.h
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.h
@@ -107,6 +107,7 @@ public:
 	Q_SLOT void savePersistentSettings();
 	Q_SLOT void resetPersistentSettings();
 
+	void setCurrentStageId(int stageId);
 	void setClassNamesFilter(const QStringList &class_names);
 
 	int stagesCount() const;

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -1766,6 +1766,7 @@ void RunsPlugin::report_startListClasses()
 	quickevent::gui::ReportOptionsDialog dlg(fwk);
 	dlg.setPersistentSettingsId("startListClassesReportOptions");
 	dlg.loadPersistentSettings();
+	dlg.setCurrentStageId(getPlugin<EventPlugin>()->currentStageId());
 	dlg.setStartListOptionsVisible(true);
 	dlg.setPageLayoutVisible(true);
 	dlg.setStartTimeFormatVisible(true);
@@ -1791,6 +1792,7 @@ void RunsPlugin::report_startListClubs()
 	quickevent::gui::ReportOptionsDialog dlg(fwk);
 	dlg.setPersistentSettingsId("startListClubsReportOptions");
 	dlg.loadPersistentSettings();
+	dlg.setCurrentStageId(getPlugin<EventPlugin>()->currentStageId());
 	dlg.setClassFilterVisible(false);
 	dlg.setStartListOptionsVisible(true);
 	dlg.setStartListPrintVacantsVisible(false);
@@ -1818,6 +1820,7 @@ void RunsPlugin::report_startListStarters()
 	quickevent::gui::ReportOptionsDialog dlg(fwk);
 	dlg.setPersistentSettingsId("startListStartersReportOptions");
 	dlg.loadPersistentSettings();
+	dlg.setCurrentStageId(getPlugin<EventPlugin>()->currentStageId());
 	dlg.setClassFilterVisible(true);
 	dlg.setStartListOptionsVisible(true);
 	dlg.setStartListPrintVacantsVisible(false);

--- a/quickevent/app/quickevent/plugins/Runs/src/runswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runswidget.cpp
@@ -993,6 +993,7 @@ void RunsWidget::export_startList_stage_csv_sime()
 	quickevent::gui::ReportOptionsDialog dlg(fwk);
 	dlg.setPersistentSettingsId("startListCsvSimeReportOptions");
 	dlg.loadPersistentSettings();
+	dlg.setCurrentStageId(selectedStageId());
 	dlg.setStartListOptionsVisible(true);
 	dlg.setVacantsVisible(false);
 	dlg.setPageLayoutVisible(false);


### PR DESCRIPTION
finish #805, actual stage is reflected and only the starts from that stage are listed.