### PR TITLE
Feature/relaysmode - hide Relays tab when not relevant 

### DIFF
--- a/libqf/libqfgui/src/framework/partswitch.cpp
+++ b/libqf/libqfgui/src/framework/partswitch.cpp
@@ -47,12 +47,18 @@ void PartSwitch::addPartWidget(PartWidget *widget)
 	});
 	bt->setText(widget->title());
 	bt->setPartIndex(buttonCount());
-	addWidget(bt);
+	m_partActions.append(addWidget(bt));
 	{
 		QIcon ico = widget->createIcon();
 		//bt->setIconSize(QSize{128, 128});
 		bt->setIcon(ico);
 	}
+}
+
+void PartSwitch::setPartVisible(int part_index, bool visible)
+{
+	if(part_index >= 0 && part_index < m_partActions.size())
+		m_partActions[part_index]->setVisible(visible);
 }
 
 void PartSwitch::setCurrentPartIndex(int ix, bool is_active)
@@ -82,21 +88,14 @@ void PartSwitch::setCurrentPartIndex(int ix, bool is_active)
 
 int PartSwitch::buttonCount()
 {
-	QList<PartSwitchToolButton*> lst = findChildren<PartSwitchToolButton*>(QString(), Qt::FindDirectChildrenOnly);
-	return lst.count();
+	return m_partActions.size();
 }
 
 PartSwitchToolButton *PartSwitch::buttonAt(int part_index)
 {
-	PartSwitchToolButton *ret = nullptr;
-	const QList<PartSwitchToolButton*> lst = findChildren<PartSwitchToolButton*>(QString(), Qt::FindDirectChildrenOnly);
-	for(auto bt : lst) {
-		if(bt->partIndex() == part_index) {
-			ret = bt;
-			break;
-		}
-	}
-	return ret;
+	if(part_index < 0 || part_index >= m_partActions.size())
+		return nullptr;
+	return qobject_cast<PartSwitchToolButton*>(widgetForAction(m_partActions[part_index]));
 }
 
 

--- a/libqf/libqfgui/src/framework/partswitch.cpp
+++ b/libqf/libqfgui/src/framework/partswitch.cpp
@@ -47,7 +47,7 @@ void PartSwitch::addPartWidget(PartWidget *widget)
 	});
 	bt->setText(widget->title());
 	bt->setPartIndex(buttonCount());
-	m_partActions.append(addWidget(bt));
+	addWidget(bt);
 	{
 		QIcon ico = widget->createIcon();
 		//bt->setIconSize(QSize{128, 128});
@@ -57,8 +57,14 @@ void PartSwitch::addPartWidget(PartWidget *widget)
 
 void PartSwitch::setPartVisible(int part_index, bool visible)
 {
-	if(part_index >= 0 && part_index < m_partActions.size())
-		m_partActions[part_index]->setVisible(visible);
+	for(auto *a : actions()) {
+		if(auto *bt = qobject_cast<PartSwitchToolButton*>(widgetForAction(a))) {
+			if(bt->partIndex() == part_index) {
+				a->setVisible(visible);
+				break;
+			}
+		}
+	}
 }
 
 void PartSwitch::setCurrentPartIndex(int ix, bool is_active)
@@ -88,14 +94,18 @@ void PartSwitch::setCurrentPartIndex(int ix, bool is_active)
 
 int PartSwitch::buttonCount()
 {
-	return m_partActions.size();
+	return findChildren<PartSwitchToolButton*>(QString(), Qt::FindDirectChildrenOnly).count();
 }
 
 PartSwitchToolButton *PartSwitch::buttonAt(int part_index)
 {
-	if(part_index < 0 || part_index >= m_partActions.size())
-		return nullptr;
-	return qobject_cast<PartSwitchToolButton*>(widgetForAction(m_partActions[part_index]));
+	QList<PartSwitchToolButton*> lst = findChildren<PartSwitchToolButton*>(QString(), Qt::FindDirectChildrenOnly);
+	for(auto *bt : lst) {
+		if(bt->partIndex() == part_index) {
+			return bt;
+		}
+	}
+	return nullptr;
 }
 
 

--- a/libqf/libqfgui/src/framework/partswitch.h
+++ b/libqf/libqfgui/src/framework/partswitch.h
@@ -4,6 +4,7 @@
 #include <QToolBar>
 #include <QToolButton>
 
+#include <QList>
 #include <QPointer>
 
 namespace qf {
@@ -40,6 +41,7 @@ public:
 	~PartSwitch() Q_DECL_OVERRIDE;
 public:
 	void addPartWidget(PartWidget *widget);
+	void setPartVisible(int part_index, bool visible);
 
 	Q_SIGNAL void partActivated(int ix, bool is_active);
 	void setCurrentPartIndex(int ix, bool is_active = true);
@@ -49,6 +51,7 @@ private:
 private:
 	QPointer<StackedCentralWidget> m_centralWidget;
 	int m_currentPartIndex;
+	QList<QAction*> m_partActions;
 };
 
 }}}

--- a/libqf/libqfgui/src/framework/partswitch.h
+++ b/libqf/libqfgui/src/framework/partswitch.h
@@ -4,7 +4,6 @@
 #include <QToolBar>
 #include <QToolButton>
 
-#include <QList>
 #include <QPointer>
 
 namespace qf {
@@ -51,7 +50,6 @@ private:
 private:
 	QPointer<StackedCentralWidget> m_centralWidget;
 	int m_currentPartIndex;
-	QList<QAction*> m_partActions;
 };
 
 }}}

--- a/libqf/libqfgui/src/framework/stackedcentralwidget.cpp
+++ b/libqf/libqfgui/src/framework/stackedcentralwidget.cpp
@@ -67,6 +67,13 @@ bool StackedCentralWidget::setActivePart(int part_index, bool set_active)
 	return ret;
 }
 
+void StackedCentralWidget::setPartVisible(const QString &feature_id, bool visible)
+{
+	int ix = featureToIndex(feature_id);
+	if(ix >= 0)
+		m_partSwitch->setPartVisible(ix, visible);
+}
+
 int StackedCentralWidget::featureToIndex(const QString &feature_id)
 {
 	for (int i = 0; i < m_centralWidget->count(); ++i) {

--- a/libqf/libqfgui/src/framework/stackedcentralwidget.h
+++ b/libqf/libqfgui/src/framework/stackedcentralwidget.h
@@ -27,8 +27,10 @@ public:
 
 	PartSwitch* partSwitch() {return m_partSwitch;}
 
+	using Super::setActivePart;
 	bool setActivePart(int part_index, bool set_active)  Q_DECL_OVERRIDE;
 	int featureToIndex(const QString &feature_id) Q_DECL_OVERRIDE;
+	void setPartVisible(const QString &feature_id, bool visible);
 private:
 	QStackedWidget *m_centralWidget;
 	PartSwitch *m_partSwitch;

--- a/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
@@ -9,6 +9,7 @@
 #include <quickevent/core/runstatus.h>
 
 #include <qf/gui/framework/mainwindow.h>
+#include <qf/gui/framework/stackedcentralwidget.h>
 #include <qf/gui/framework/dockwidget.h>
 #include <qf/gui/dialogs/dialog.h>
 #include <qf/gui/action.h>
@@ -68,7 +69,24 @@ void RelaysPlugin::onInstalled()
 {
 	m_partWidget = qff::initPluginWidget<RelaysWidget, PartWidget>(tr("&Relays"), featureId());
 
-	connect(getPlugin<EventPlugin>(), &Event::EventPlugin::dbEventNotify, this, &RelaysPlugin::onDbEventNotify);
+	auto *scw = qobject_cast<qff::StackedCentralWidget*>(qff::MainWindow::frameWork()->centralWidget());
+	if(scw)
+		scw->setPartVisible(featureId(), false);
+
+	auto *event_plugin = getPlugin<EventPlugin>();
+	connect(event_plugin, &Event::EventPlugin::eventOpenChanged, this, [this]() {
+		auto *scw = qobject_cast<qff::StackedCentralWidget*>(qff::MainWindow::frameWork()->centralWidget());
+		if(!scw)
+			return;
+		auto *ep = getPlugin<EventPlugin>();
+		bool event_open = ep->isEventOpen();
+		auto *cfg = event_open ? ep->eventConfig() : nullptr;
+		bool is_relays = cfg && cfg->isRelays();
+		scw->setPartVisible(featureId(), is_relays);
+		if(event_open && !is_relays && m_partWidget && m_partWidget->isActive())
+			scw->setActivePart(QStringLiteral("Runs"), true);
+	});
+	connect(event_plugin, &Event::EventPlugin::dbEventNotify, this, &RelaysPlugin::onDbEventNotify);
 
 	emit nativeInstalled();
 }

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.cpp
@@ -64,9 +64,11 @@ RunsTableWidget::RunsTableWidget(QWidget *parent) :
 			ui->tblRuns->setItemDelegateForColumn(RunsTableModel::col_course_id, m_courseItemDelegate);
 		}
 		else if (!is_open && m_courseItemDelegate) {
+			// Clear the column delegate before deleting the object; otherwise the view
+			// holds a dangling pointer and crashes on the next paint.
+			ui->tblRuns->setItemDelegateForColumn(RunsTableModel::col_course_id, nullptr);
 			delete m_courseItemDelegate;
 			m_courseItemDelegate = nullptr;
-			ui->tblRuns->setItemDelegateForColumn(RunsTableModel::col_course_id, nullptr);
 		}
 	});
 	//ui->tblRuns->setSelectionMode(QTableView::SingleSelection);

--- a/quickevent/app/quickevent/plugins/Runs/src/runswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runswidget.cpp
@@ -427,9 +427,11 @@ void RunsWidget::settleDownInPartWidget(::PartWidget *part_widget)
 		auto *ep = getPlugin<EventPlugin>();
 		auto *cfg = ep->isEventOpen() ? ep->eventConfig() : nullptr;
 		bool enabled = !(cfg && cfg->isRelays());
-		for(const char *path : {"print", "import", "export"})
-			if(auto *a = part_widget->menuBar()->actionForPath(path))
+		for(const char *path : {"print", "import", "export"}) {
+			if(auto *a = part_widget->menuBar()->actionForPath(path)) {
 				a->setEnabled(enabled);
+			}
+		}
 	};
 	connect(getPlugin<EventPlugin>(), &EventPlugin::eventOpenChanged, this, updateMenuEnabled);
 	updateMenuEnabled();

--- a/quickevent/app/quickevent/plugins/Runs/src/runswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runswidget.cpp
@@ -422,6 +422,17 @@ void RunsWidget::settleDownInPartWidget(::PartWidget *part_widget)
 		bt->setCheckable(true);
 		connect(bt, &QPushButton::toggled, ui->frmDrawing, &QFrame::setVisible);
 	}
+
+	auto updateMenuEnabled = [part_widget]() {
+		auto *ep = getPlugin<EventPlugin>();
+		auto *cfg = ep->isEventOpen() ? ep->eventConfig() : nullptr;
+		bool enabled = !(cfg && cfg->isRelays());
+		for(const char *path : {"print", "import", "export"})
+			if(auto *a = part_widget->menuBar()->actionForPath(path))
+				a->setEnabled(enabled);
+	};
+	connect(getPlugin<EventPlugin>(), &EventPlugin::eventOpenChanged, this, updateMenuEnabled);
+	updateMenuEnabled();
 }
 
 namespace {


### PR DESCRIPTION
Show `Relays` tab only for relays and teams event. Hide also actions (Print, Import, Export) in `Runs` tab.
#972