### PR TITLE
Runs: add prev/next class navigation buttons

### DIFF
--- a/quickevent/app/quickevent/plugins/Runs/src/runswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runswidget.cpp
@@ -36,6 +36,7 @@
 #include <QLabel>
 #include <QInputDialog>
 #include <QTimer>
+#include <QToolButton>
 #include <QRandomGenerator>
 
 #include <algorithm>
@@ -372,6 +373,23 @@ void RunsWidget::settleDownInPartWidget(::PartWidget *part_widget)
 		main_tb->addWidget(m_cbxClasses);
 	}
 	lbl_classes->setBuddy(m_cbxClasses);
+	{
+		// Quick jump to the previous/next class for visual checking.
+		m_btPrevClass = new QToolButton();
+		m_btPrevClass->setArrowType(Qt::LeftArrow);
+		m_btPrevClass->setToolTip(tr("Previous class"));
+		connect(m_btPrevClass, &QToolButton::clicked, this, [this]() { stepClass(-1); });
+		main_tb->addWidget(m_btPrevClass);
+
+		m_btNextClass = new QToolButton();
+		m_btNextClass->setArrowType(Qt::RightArrow);
+		m_btNextClass->setToolTip(tr("Next class"));
+		connect(m_btNextClass, &QToolButton::clicked, this, [this]() { stepClass(1); });
+		main_tb->addWidget(m_btNextClass);
+
+		connect(m_cbxClasses, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &RunsWidget::updateClassNavButtons);
+		updateClassNavButtons(); // start disabled until classes are loaded
+	}
 	{
 		auto *lbl_leg = new QLabel(tr("&Leg "));
 		m_toolbarActionLabelLeg = main_tb->addWidget(lbl_leg);
@@ -1214,6 +1232,30 @@ void RunsWidget::updateClassComboBox()
 	m_cbxClasses->insertItem(0, tr("--- all ---"), 0);
 	m_cbxClasses->setCurrentIndex(0);
 	m_cbxClasses->blockSignals(false);
+	updateClassNavButtons();
+}
+
+void RunsWidget::stepClass(int step)
+{
+	int cnt = m_cbxClasses->count();
+	if(cnt <= 1)
+		return; // only the "--- all ---" pseudo-item is present
+	int ix = m_cbxClasses->currentIndex();
+	// index 0 is "--- all ---", step only through real classes (indices 1 .. cnt-1)
+	int new_ix = qBound(1, ix + step, cnt - 1);
+	if(new_ix != ix)
+		m_cbxClasses->setCurrentIndex(new_ix); // triggers currentDataChanged -> reload()
+}
+
+void RunsWidget::updateClassNavButtons()
+{
+	if(!m_btPrevClass || !m_btNextClass)
+		return;
+	int cnt = m_cbxClasses->count();
+	int ix = m_cbxClasses->currentIndex();
+	// real classes live at indices 1 .. cnt-1 (index 0 is "--- all ---")
+	m_btPrevClass->setEnabled(ix > 1);
+	m_btNextClass->setEnabled(cnt > 1 && ix < cnt - 1);
 }
 
 void RunsWidget::updateLegsComboBox()

--- a/quickevent/app/quickevent/plugins/Runs/src/runswidget.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runswidget.h
@@ -9,6 +9,7 @@ class QComboBox;
 class QCheckBox;
 class QTextStream;
 class QLabel;
+class QToolButton;
 
 namespace qf {
 namespace core {
@@ -88,6 +89,9 @@ private:
 
 	void updateClassComboBox();
 	void updateLegsComboBox();
+
+	void stepClass(int step);
+	void updateClassNavButtons();
 private:
 	enum class DrawMethod : int {Invalid = 0, RandomNumber,
 		EquidistantClubs, RandomizedEquidistantClubs, StageReverseOrder, Handicap,
@@ -95,6 +99,8 @@ private:
 
 	Ui::RunsWidget *ui;
 	qf::gui::ForeignKeyComboBox *m_cbxClasses = nullptr;
+	QToolButton *m_btPrevClass = nullptr;
+	QToolButton *m_btNextClass = nullptr;
 	QComboBox *m_cbxStage = nullptr;
 	QComboBox *m_cbxLeg = nullptr;
 	QAction *m_toolbarActionLabelLeg = nullptr;

--- a/quickevent/app/quickevent/quickevent-cs_CZ.ts
+++ b/quickevent/app/quickevent/quickevent-cs_CZ.ts
@@ -6691,6 +6691,16 @@ Stskněte tlačítko pro obnovení pro zobrazení importovaných dat.</translati
         <translation>Metoda</translation>
     </message>
     <message>
+        <location filename="plugins/Runs/src/runswidget.cpp" line="380"/>
+        <source>Previous class</source>
+        <translation>Předchozí kategorie</translation>
+    </message>
+    <message>
+        <location filename="plugins/Runs/src/runswidget.cpp" line="386"/>
+        <source>Next class</source>
+        <translation>Další kategorie</translation>
+    </message>
+    <message>
         <location filename="plugins/Runs/src/runswidget.ui" line="101"/>
         <source>Remove all start times and unlock drawing for this class.</source>
         <oldsource>Draw selected  class or all classes when all the clases are selected.</oldsource>


### PR DESCRIPTION
## Summary
Adds **`<`** and **`>`** toolbar buttons next to the class combo box in the Runs/Stages widget, so classes can be stepped through quickly for visual checking.

## Details
- Navigation steps only through real classes — the `--- all ---` pseudo-item is skipped.
- Stepping is clamped via `qBound`, so navigating past the first or last class is a safe no-op (cannot crash).
- The buttons are disabled at the boundaries (on the first / last class).
- Czech translations for the two new tooltips are included.

## Testing
- Full CMake build (Qt 6.11.1 / MinGW 13.1) passes with no errors or warnings.
- Verified by running the app and stepping through classes in the Runs/Stages panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)