### PR TITLE
Update github actions

### DIFF
--- a/.github/actions/appimage/action.yml
+++ b/.github/actions/appimage/action.yml
@@ -55,7 +55,7 @@ runs:
       shell: bash
 
     - name: Upload AppImage
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: quickevent-${{ env.VERSION }}-x86_64.Appimage
         path: QuickEvent-*-x86_64.AppImage

--- a/.github/actions/cmake/action.yml
+++ b/.github/actions/cmake/action.yml
@@ -23,7 +23,7 @@ runs:
     # Linux deps
     - name: Install/cache clazy, ninja, openldap, doctest libfuse, and Qt's dependencies
       if: runner.os != 'Windows'
-      uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+      uses: awalsh128/cache-apt-pkgs-action@v1.6.0
       with:
         packages: ninja-build libgl1-mesa-dev libpulse-dev libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-util1 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev clazy libfuse-dev libgstreamer-gl1.0-0 libgstreamer-plugins-base1.0-0
         version: 1.0

--- a/.github/actions/run-linter/action.yml
+++ b/.github/actions/run-linter/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Setup CMake
       uses: ./.github/actions/cmake
       with:
-        qt_version: 6.10.2
+        qt_version: 6.10.3
         use_qt6: ON
         modules: qtserialport qtmultimedia
         additional_cmake_args: -DCMAKE_GLOBAL_AUTOGEN_TARGET=ON -DCMAKE_AUTOGEN_ORIGIN_DEPENDS=OFF

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup CMake
         uses: ./.github/actions/cmake
         with:
-          qt_version: 6.10.2
+          qt_version: 6.10.3
           use_qt6: ON
           modules: qtserialport qtmultimedia
           additional_cmake_args: -DCMAKE_INSTALL_PREFIX='${{ github.workspace }}/install/usr'

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup CMake
         uses: ./.github/actions/cmake
         with:
-          qt_version: 6.10.2
+          qt_version: 6.10.3
           qt_arch: win64_mingw
           use_qt6: ON
           modules: qtserialport qtmultimedia
@@ -101,7 +101,7 @@ jobs:
         run: iscc "-DBUILD_DIR=${{ github.workspace }}/install" "-DVERSION=${{ env.VERSION }}" quickevent/quickevent.iss
 
       - name: Upload installer
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: quickevent-${{ env.VERSION }}-setup.exe
           path: ${{ github.workspace }}/install/_inno/quickevent/quickevent-*-setup.exe

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           cache: true
-          version: 6.10.2
+          version: 6.10.3
           install-deps: false
           modules: qtserialport qtmultimedia
 
@@ -88,7 +88,7 @@ jobs:
             '${{ github.workspace }}/install/quickevent.app'
 
       - name: Upload DMG
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: quickevent-${{ env.VERSION }}.dmg
           path: ${{ github.workspace }}/quickevent-*.dmg

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -40,13 +40,13 @@ jobs:
           cargo install --version ${MDBOOK_VERSION} mdbook
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Build with mdBook
         run: |
           cd ./doc
           mdbook build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./doc/book
 
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Mostly latest versions with support of Node.js 24
Qt updated to Qt6.10.3

Update to Qt6.11 don't work now, waiting for new release (>3.3) of aqtinstall 
Cache depends on awalsh128/cache-apt-pkgs-action, waiting for new release ( >1.6)
