### PR TITLE
fix: missing Date element value in both startlist and results for relays

### DIFF
--- a/quickevent/app/quickevent/plugins/Event/src/eventconfig.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/eventconfig.cpp
@@ -132,13 +132,13 @@ void EventConfig::save(const QString &path_to_save)
 			else
 				val_str = val.toString();
 			q_up.bindValue(":key", key);
-			q_up.bindValue(":val", val);
+			q_up.bindValue(":val", val_str);
 			q_up.exec(qf::core::Exception::Throw);
 			if(q_up.numRowsAffected() < 1) {
 				QString type = val.typeName();
 				q_ins.bindValue(":key", key);
 				q_ins.bindValue(":type", type);
-				q_ins.bindValue(":val", val);
+				q_ins.bindValue(":val", val_str);
 				q_ins.exec(qf::core::Exception::Throw);
 			}
 		}

--- a/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
@@ -582,8 +582,8 @@ QString RelaysPlugin::resultsIofXml30()
 			event_lst.insert(event_lst.count(), QVariantList{"Id", QVariantMap{{"type", "ORIS"}}, event.value("importId")});
 		event_lst.insert(event_lst.count(), QVariantList{"Name", event.value("name")});
 		event_lst.insert(event_lst.count(), QVariantList{"StartTime",
-				   QVariantList{"Date", event.value("date")},
-				   QVariantList{"Time", event.value("time")}
+				   QVariantList{"Date", start00.date().toString(Qt::ISODate)},
+				   QVariantList{"Time", start00.time().toString(Qt::ISODate)}
 		});
 		event_lst.insert(event_lst.count(),
 			QVariantList{"Official",
@@ -864,8 +864,8 @@ QString RelaysPlugin::startListIofXml30()
 			event_lst.insert(event_lst.count(), QVariantList{"Id", QVariantMap{{"type", "ORIS"}}, event.value("importId")});
 		event_lst.insert(event_lst.count(), QVariantList{"Name", event.value("name")});
 		event_lst.insert(event_lst.count(), QVariantList{"StartTime",
-				   QVariantList{"Date", event.value("date")},
-				   QVariantList{"Time", event.value("time")}
+				   QVariantList{"Date", start00.date().toString(Qt::ISODate)},
+				   QVariantList{"Time", start00.time().toString(Qt::ISODate)}
 		});
 		event_lst.insert(event_lst.count(),
 			QVariantList{"Official",


### PR DESCRIPTION
The same issue as for individual race that was fixed in #1128.

Fixes issue #1127.