### PR TITLE
Radio sender

### DIFF
--- a/.agents/skills/build-dir/SKILL.md
+++ b/.agents/skills/build-dir/SKILL.md
@@ -8,3 +8,4 @@ disable-model-invocation: false
 
 * load global skill cpp-indent
 * build dir is /home/fanda/b/quickbox
+* build with 16 cores

--- a/.agents/skills/build-dir/SKILL.md
+++ b/.agents/skills/build-dir/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: build-dir
+description: Build dir
+disable-model-invocation: false
+---
+
+## Instructions
+
+* load global skill cpp-indent
+* build dir is /home/fanda/b/quickbox

--- a/.agents/skills/build-dir/SKILL.md
+++ b/.agents/skills/build-dir/SKILL.md
@@ -6,6 +6,6 @@ disable-model-invocation: false
 
 ## Instructions
 
-* load global skill cpp-indent
+* TABs indentation
 * build dir is /home/fanda/b/quickbox
 * build with 16 cores

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MESSAGES CONTROL]
+disable=line-too-long

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,0 @@
-[MESSAGES CONTROL]
-disable=line-too-long

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,3 @@
+{
+  "hard_tabs": true
+}

--- a/libqf/libqfcore/src/sql/qxsql.cpp
+++ b/libqf/libqfcore/src/sql/qxsql.cpp
@@ -81,9 +81,14 @@ QList<Record> QxSqlApi::listOneOrMoreRecords(const QString &table, const std::op
 
 	QString qs = QString("SELECT %1 FROM %2").arg(fieldsStr, table);
 
-	if (id.has_value()) {
+	if (id.has_value() && limit.has_value() && *limit == 1) {
+		qs += QString(" WHERE id = %1").arg(*id);
+	}
+	else if (id.has_value()) {
 		qs += QString(" WHERE id >= %1").arg(*id);
 	}
+
+	qs += QString(" ORDER BY id");
 
 	if (limit.has_value()) {
 		qs += QString(" LIMIT %1").arg(*limit);

--- a/libqf/libqfcore/src/sql/qxsql.cpp
+++ b/libqf/libqfcore/src/sql/qxsql.cpp
@@ -61,7 +61,6 @@ bool QxSqlApi::updateRecord(const QString &table, qint64 id, const Record &recor
 
 	QString qs = QString("UPDATE %1 SET %2 WHERE id = %3")
 			.arg(table, keyVals.join(", "), QString::number(id));
-
 	ExecResult res = exec(qs, record);
 	return res.rowsAffected == 1;
 }

--- a/libqf/libqfgui/src/framework/mainwindow.h
+++ b/libqf/libqfgui/src/framework/mainwindow.h
@@ -126,14 +126,14 @@ static T* getPlugin()
 }
 
 template<typename Widget, typename PartWidget>
-static PartWidget* initPluginWidget(QString title, QString featureId)
+static std::pair<PartWidget*, Widget*> initPluginWidget(QString title, QString featureId)
 {
 	auto* widget = new Widget();
 	auto *part_widget = new PartWidget(title, featureId);
 	qf::gui::framework::MainWindow::frameWork()->addPartWidget(part_widget);
 	part_widget->addWidget(widget);
 	widget->settleDownInPartWidget(part_widget);
-	return part_widget;
+	return std::make_pair(part_widget, widget);
 }
 
 }}}

--- a/libqf/libqfgui/src/model/tablemodel.cpp
+++ b/libqf/libqfgui/src/model/tablemodel.cpp
@@ -676,7 +676,7 @@ void TableModel::handleQxRecChng(const core::sql::QxRecChng &recchng, QObject *s
 				}
 			}
 		} else {
-			qfWarning() << "cannot find table column:" << (table_name + ".id");
+			qfMessage() << "handleQxRecChng: table model doesn't contain column:" << (table_name + ".id");
 		}
 		return -1;
 	};

--- a/libqf/libqfgui/src/model/tablemodel.cpp
+++ b/libqf/libqfgui/src/model/tablemodel.cpp
@@ -13,6 +13,7 @@
 #include <QPixmap>
 #include <QIcon>
 #include <algorithm>
+#include <qnamespace.h>
 
 namespace qfc = qf::core;
 namespace qfu = qf::core::utils;
@@ -38,7 +39,7 @@ bool TableModel::ColumnDefinition::matchesSqlId(const QString column_name) const
 namespace {
 const auto DEFAULT_TIME_FORMAT = QStringLiteral("hh:mm:ss");
 const auto DEFAULT_DATE_FORMAT = QStringLiteral("yyyy-MM-dd");
-const auto DEFAULT_DATETIME_FORMAT = QStringLiteral("yyyy-MM-ddThh:mm:ss");
+// const auto DEFAULT_DATETIME_FORMAT = QStringLiteral("yyyy-MM-ddThh:mm:ss");
 }
 
 TableModel::TableModel(QObject *parent)
@@ -159,29 +160,18 @@ QVariant TableModel::data(const QModelIndex &index, int role) const
 		QString format = cd.format();
 		if(format.isEmpty()) {
 			if(type == QMetaType::QDate) {
-				format = DEFAULT_DATE_FORMAT;
+				QDate d = ret.toDate();
+				return d.toString(DEFAULT_DATE_FORMAT);
 			}
-			else if(type == QMetaType::QTime) {
-				format = DEFAULT_TIME_FORMAT;
-				//qfInfo() << "format" << format;
-			}
-			else if(type == QMetaType::QDateTime) {
-				format = DEFAULT_DATETIME_FORMAT;
-				//qfInfo() << "format" << format;
-			}
-		}
-		if(!format.isEmpty()) {
 			if(type == QMetaType::QTime) {
 				QTime t = ret.toTime();
-				ret = t.toString(format);
+				return t.toString(DEFAULT_TIME_FORMAT);
 			}
-			else if(type == QMetaType::QDate) {
-				QDate d = ret.toDate();
-				ret = d.toString(format);
-			}
-			else if(type == QMetaType::QDateTime) {
-				QDateTime dt = ret.toDateTime();
-				ret = dt.toLocalTime().toString(format);
+			if(type == QMetaType::QDateTime) {
+				QDateTime dt = ret.toDateTime().toLocalTime();
+				if(auto millis = dt.time().msec(); millis > 0)
+					return dt.toString(Qt::ISODateWithMs);
+				return dt.toString(Qt::ISODate);
 			}
 		}
 	}

--- a/libqf/libqfgui/src/model/tablemodel.cpp
+++ b/libqf/libqfgui/src/model/tablemodel.cpp
@@ -12,8 +12,8 @@
 #include <QColor>
 #include <QPixmap>
 #include <QIcon>
+
 #include <algorithm>
-#include <qnamespace.h>
 
 namespace qfc = qf::core;
 namespace qfu = qf::core::utils;

--- a/libqf/libqfgui/src/model/tablemodel.h
+++ b/libqf/libqfgui/src/model/tablemodel.h
@@ -44,7 +44,7 @@ public:
 		{
 		public:
 			QString fieldName; //!< ID to pair ColumnDefinitions with fields
-			int fieldIndex;
+			int fieldIndex = -1;
 			QString caption;
 			QString toolTip;
 			//int initialSize; //!< initial width of column
@@ -52,10 +52,10 @@ public:
 			bool isVirtual = false;
 			Qt::Alignment alignment;
 			QString format; //!< format for date, time, ... types
-			int castType;
+			int castType = QMetaType::UnknownType;
 			QVariantMap castProperties;
 
-			Data(const QString &fldname = QString()) : fieldName(fldname), fieldIndex(-1), castType(QMetaType::UnknownType) {}
+			Data(const QString &fldname = QString()) : fieldName(fldname) {}
 		};
 	private:
 		QSharedDataPointer<Data> d;
@@ -231,4 +231,3 @@ protected:
 }}}
 
 Q_DECLARE_METATYPE(qf::gui::model::TableModel::ColumnDefinition)
-

--- a/libquickevent/libquickeventcore/src/exporters/stageresultscsvexporter.cpp
+++ b/libquickevent/libquickeventcore/src/exporters/stageresultscsvexporter.cpp
@@ -134,7 +134,7 @@ void StageResultsCsvExporter::exportClass(int class_id, QTextStream &csv)
 		while(q2.next()) {
 			auto run_status = quickevent::core::RunStatus::fromQuery(q2);
 			int time_ms = q2.value(QStringLiteral("timeMs")).toInt();
-			QString stime = og::TimeMs(time_ms).toString('.');
+			QString stime = og::TimeMs(time_ms).toString();
 			bool is_finish = q2.value(QStringLiteral("finishTimeMs")).toInt() > 0;
 			if(run_status.isOk() && is_finish) {
 				pos++;

--- a/libquickevent/libquickeventcore/src/exporters/stageresultshtmlexporter.cpp
+++ b/libquickevent/libquickeventcore/src/exporters/stageresultshtmlexporter.cpp
@@ -76,7 +76,7 @@ void StageResultsHtmlExporter::exportClass(int class_id, const QVariantList &cla
 			auto run_status = quickevent::core::RunStatus::fromQuery(q2);
 			QString status = run_status.toHtmlExportString();
 			int time_ms = q2.value(QStringLiteral("timeMs")).toInt();
-			QString stime = og::TimeMs(time_ms).toString('.');
+			QString stime = og::TimeMs(time_ms).toString();
 			QString spos;
 			if(run_status.isOk()) {
 				if(time_ms != prev_time_ms)

--- a/libquickevent/libquickeventcore/src/exporters/stagestartlisthtmlexporter.cpp
+++ b/libquickevent/libquickeventcore/src/exporters/stagestartlisthtmlexporter.cpp
@@ -71,7 +71,7 @@ void StageStartListHtmlExporter::exportClass(int class_id, const QVariantList &c
 		while(q2.next()) {
 			pos++;
 			int time_ms = q2.value(QStringLiteral("startTimeMs")).toInt();
-			QString stime = og::TimeMs(time_ms).toString('.');
+			QString stime = og::TimeMs(time_ms).toString();
 			QVariantList tr2{"tr"};
 			if(pos % 2)
 				tr2 << QVariantMap{{QStringLiteral("class"), QStringLiteral("odd")}};

--- a/libquickevent/libquickeventcore/src/og/timems.cpp
+++ b/libquickevent/libquickeventcore/src/og/timems.cpp
@@ -3,6 +3,7 @@
 #include <qf/core/log.h>
 
 #include <QString>
+#include <QRegularExpression>
 
 
 
@@ -60,48 +61,30 @@ QString TimeMs::toString(QChar sec_sep, QChar msec_sep) const
 	return ret;
 }
 
-static int str2int(const QString &str)
+QString TimeMs::toString() const
 {
-	int ret = 0;
-	QString s = str.trimmed();
-	if(!s.isEmpty()) {
-		bool ok;
-		ret = s.toInt(&ok);
-		if(!ok)
-			qfWarning() << "Invalid OGTime string" << str;
+	if(msec() % 1000) {
+		return toString('.', '/');
 	}
-	return ret;
+	return toString('.', {});
 }
+
+
 
 TimeMs TimeMs::fromString(const QString &time_str)
 {
 	if(time_str.isEmpty())
 		return TimeMs();
 
-	int msec = 0;
-	int sec = 0;
-	int min = 0;
-	int ix1 = 0;
-
-	int ix2 = time_str.indexOf('.', ix1);
-	if(ix2 < 0)
-		ix2 = time_str.indexOf(':', ix1);
-	if(ix2 < 0)
-		ix2 = time_str.indexOf('-', ix1);
-	if(ix2 < 0)
-		ix2 = time_str.indexOf(',', ix1);
-	if(ix2 < 0)
-		ix2 = time_str.length();
-	min = str2int(time_str.mid(ix1, ix2));
-	ix1 = ix2 + 1;
-
-	ix2 = time_str.indexOf('/', ix1);
-	if(ix2 < 0)
-		ix2 = time_str.length();
-	sec = str2int(time_str.mid(ix1, ix2));
-	ix1 = ix2 + 1;
-
-	msec = str2int(time_str.mid(ix1));
+	static const QRegularExpression re(R"(^(\d+)(?:[.:\-,](\d+)(?:\/(\d+))?)?$)");
+	auto m = re.match(time_str.trimmed());
+	if(!m.hasMatch()) {
+		qfWarning() << "Invalid OGTime string" << time_str;
+		return TimeMs();
+	}
+	int min  = m.captured(1).toInt();
+	int sec  = m.captured(2).toInt();
+	int msec = m.captured(3).toInt();
 
 	return TimeMs(msec + ((sec + (min * 60)) * 1000));
 }

--- a/libquickevent/libquickeventcore/src/og/timems.h
+++ b/libquickevent/libquickeventcore/src/og/timems.h
@@ -47,7 +47,7 @@ public:
 
 	static TimeMs fromVariant(const QVariant &time_v);
 	static TimeMs fromString(const QString &time_str);
-	QString toString(QChar sec_sep = QChar('.'), QChar msec_sep = QChar()) const;
+	QString toString() const;
 	int msec() const {return isValid()? m_msec: 0;}
 
 	/// while time2 < time1 add 12 hours to time2 and return it
@@ -56,8 +56,8 @@ public:
 
 	static void registerQVariantFunctions();
 
-	//static void setOneTenthSecPrecision(bool b) { m_oneTenthSecPrecision = b; }
-	//static bool isOneTenthSecPrecision() { return m_oneTenthSecPrecision; }
+private:
+	QString toString(QChar sec_sep, QChar msec_sep) const;
 private:
 	int m_msec;
 	bool m_isValid;

--- a/libquickevent/libquickeventgui/src/og/sqltablemodel.cpp
+++ b/libquickevent/libquickeventgui/src/og/sqltablemodel.cpp
@@ -26,15 +26,13 @@ QVariant SqlTableModel::data(const QModelIndex &index, int role) const
 		int type = v.userType();
 		if(type == qMetaTypeId<core::og::TimeMs>()) {
 			auto t = v.value<core::og::TimeMs>();
-			if (t.msec() > 0) {
-				return t.toString(':', '.');
-			}
 			return t.toString();
 		}
 		if(type == qMetaTypeId<core::si::SiId>()) {
 			int id = (int)v.value<core::si::SiId>();
-			if(id == 0)
-				return QString();// QStringLiteral("null");
+			if(id == 0) {
+				return QString();
+			}
 			return id;
 		}
 	}

--- a/libquickevent/libquickeventgui/src/og/sqltablemodel.cpp
+++ b/libquickevent/libquickeventgui/src/og/sqltablemodel.cpp
@@ -29,7 +29,7 @@ QVariant SqlTableModel::data(const QModelIndex &index, int role) const
 			return t.toString();
 		}
 		if(type == qMetaTypeId<core::si::SiId>()) {
-			int id = (int)v.value<core::si::SiId>();
+			auto id = static_cast<int>(v.value<core::si::SiId>());
 			if(id == 0) {
 				return QString();
 			}

--- a/libquickevent/libquickeventgui/src/og/sqltablemodel.cpp
+++ b/libquickevent/libquickeventgui/src/og/sqltablemodel.cpp
@@ -26,6 +26,9 @@ QVariant SqlTableModel::data(const QModelIndex &index, int role) const
 		int type = v.userType();
 		if(type == qMetaTypeId<core::og::TimeMs>()) {
 			auto t = v.value<core::og::TimeMs>();
+			if (t.msec() > 0) {
+				return t.toString(':', '.');
+			}
 			return t.toString();
 		}
 		if(type == qMetaTypeId<core::si::SiId>()) {

--- a/quickevent/app/quickevent/CMakeLists.txt
+++ b/quickevent/app/quickevent/CMakeLists.txt
@@ -113,6 +113,9 @@ add_executable(quickevent
 	plugins/Event/src/services/punchingtest/punchingtestservice.h plugins/Event/src/services/punchingtest/punchingtestservice.cpp
 	plugins/Event/src/services/punchingtest/punchingtestservicewidget.h plugins/Event/src/services/punchingtest/punchingtestservicewidget.cpp
 	plugins/Event/src/services/punchingtest/punchingtestservicewidget.ui
+	plugins/Event/src/services/radiosender/radiosenderconfig.cpp plugins/Event/src/services/radiosender/radiosenderconfig.h
+	plugins/Event/src/services/radiosender/radiosenderservice.cpp plugins/Event/src/services/radiosender/radiosenderservice.h
+	plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp plugins/Event/src/services/radiosender/radiosenderservicewidget.h plugins/Event/src/services/radiosender/radiosenderservicewidget.ui
 
 	plugins/Oris/src/chooseoriseventdialog.cpp
 	plugins/Oris/src/chooseoriseventdialog.ui

--- a/quickevent/app/quickevent/CMakeLists.txt
+++ b/quickevent/app/quickevent/CMakeLists.txt
@@ -167,6 +167,8 @@ add_executable(quickevent
 	plugins/Runs/src/runstabledialogwidget.ui
 	plugins/Runs/src/runstableitemdelegate.cpp
 	plugins/Runs/src/runstablemodel.cpp
+	plugins/Runs/src/runssettingspage.cpp
+	plugins/Runs/src/runssettingspage.ui
 	plugins/Runs/src/runstablewidget.cpp
 	plugins/Runs/src/runstablewidget.ui
 	plugins/Runs/src/runswidget.cpp

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
@@ -399,7 +399,6 @@ void CardReaderPlugin::updateCheckedCardValuesSql(int card_id, const quickevent:
 		{
 			QVariantMap rec {
 				{"checkTimeMs", checked_card.checkTimeMs()},
-				{"timeMs", checked_card.timeMs()},
 				{"finishTimeMs", checked_card.finishTimeMs()},
 				{"misPunch", checked_card.isMisPunch()},
 				{"badCheck", checked_card.isBadCheck()},
@@ -407,6 +406,7 @@ void CardReaderPlugin::updateCheckedCardValuesSql(int card_id, const quickevent:
 				{"penaltyTimeMs", {}},
 			};
 			app->updateDbRecord("runs", run_id, rec, this);
+			getPlugin<RunsPlugin>()->computeStageTime(run_id);
 		}
 		if (auto missing_codes = checked_card.missingCodes(); !missing_codes.isEmpty()) {
 			QStringList missing_str;
@@ -423,21 +423,6 @@ void CardReaderPlugin::updateCheckedCardValuesSql(int card_id, const quickevent:
 	catch (const std::exception &e) {
 		qfError() << "Update runs error, query:" << e.what();
 	}
-	// QString qs = "UPDATE runs SET checkTimeMs=:checkTimeMs, timeMs=:timeMs, finishTimeMs=:finishTimeMs, penaltyTimeMs=NULL,"
-	// 			 " misPunch=:misPunch, badCheck=:badCheck,"
-	// 			 " notStart=:notStart"
-	// 			 " WHERE id=" + QString::number(run_id);
-	// q.prepare(qs, qf::core::Exception::Throw);
-	// q.bindValue(QStringLiteral(":checkTimeMs"), checked_card.checkTimeMs());
-	// q.bindValue(QStringLiteral(":timeMs"), checked_card.timeMs());
-	// q.bindValue(QStringLiteral(":finishTimeMs"), checked_card.finishTimeMs());
-	// q.bindValue(QStringLiteral(":misPunch"), checked_card.isMisPunch());
-	// q.bindValue(QStringLiteral(":badCheck"), checked_card.isBadCheck());
-	// q.bindValue(QStringLiteral(":notStart"), false);
-	// q.exec(qf::core::Exception::Throw);
-	// if(q.numRowsAffected() != 1) {
-	// 	qfError() << "Update runs error, query:" << qs;
-	// }
 }
 
 void CardReaderPlugin::updateCardToRunAssignmentInPunches(int stage_id, int card_id, int run_id)

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderwidget.cpp
@@ -1317,4 +1317,3 @@ void CardReaderWidget::readStationBackupMemory()
 }
 
 #include "cardreaderwidget.moc"
-

--- a/quickevent/app/quickevent/plugins/Classes/src/classesplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Classes/src/classesplugin.cpp
@@ -62,7 +62,7 @@ ClassesPlugin::ClassesPlugin(QObject *parent)
 
 void ClassesPlugin::onInstalled()
 {
-	auto [m_partWidget, _] = qff::initPluginWidget<ClassesWidget, PartWidget>(tr("Classes"), featureId());
+	qff::initPluginWidget<ClassesWidget, PartWidget>(tr("Classes"), featureId());
 }
 
 QObject *ClassesPlugin::createClassDocument(QObject *parent)

--- a/quickevent/app/quickevent/plugins/Classes/src/classesplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Classes/src/classesplugin.cpp
@@ -62,7 +62,7 @@ ClassesPlugin::ClassesPlugin(QObject *parent)
 
 void ClassesPlugin::onInstalled()
 {
-	m_partWidget = qff::initPluginWidget<ClassesWidget, PartWidget>(tr("Classes"), featureId());
+	auto [m_partWidget, _] = qff::initPluginWidget<ClassesWidget, PartWidget>(tr("Classes"), featureId());
 }
 
 QObject *ClassesPlugin::createClassDocument(QObject *parent)

--- a/quickevent/app/quickevent/plugins/Classes/src/drawing/iganttitem.cpp
+++ b/quickevent/app/quickevent/plugins/Classes/src/drawing/iganttitem.cpp
@@ -52,6 +52,13 @@ const GanttItem *IGanttItem::ganttItem() const
 
 GanttItem *IGanttItem::ganttItem()
 {
-	return const_cast<GanttItem*>(((const IGanttItem*)this)->ganttItem());
+	GanttItem *ret = nullptr;
+	for (QGraphicsItem *it = m_graphicsItem; it; it = it->parentItem()) {
+		ret = dynamic_cast<GanttItem*>(it);
+		if(ret)
+			break;
+	}
+	QF_ASSERT_EX(ret != nullptr, "Bad parent!");
+	return ret;
 }
 

--- a/quickevent/app/quickevent/plugins/Event/qml/DbSchema.qml
+++ b/quickevent/app/quickevent/plugins/Event/qml/DbSchema.qml
@@ -212,6 +212,13 @@ Schema {
 					comment: 'in miliseconds'
 				},
 
+				Field { name: 'startGateTime'; type: DateTime {}
+					comment: 'DateTime when competitor crossed start photocell'
+				},
+				Field { name: 'finishGateTime'; type: DateTime {}
+					comment: 'DateTime when competitor crossed finish photocell'
+				},
+
 				Field { name: 'isRunning'; type: Boolean { }
 					defaultValue: true;
 					notNull: true

--- a/quickevent/app/quickevent/plugins/Event/sql/create_db_psql.sql
+++ b/quickevent/app/quickevent/plugins/Event/sql/create_db_psql.sql
@@ -140,6 +140,8 @@ CREATE TABLE {{eventId}}.runs (
 	finishTimeMs integer,
 	penaltyTimeMs integer,
 	timeMs integer,
+	startGateTime timestamp with time zone,
+	finishGateTime timestamp with time zone,
 	isRunning boolean NOT NULL DEFAULT true,
 	disqualified boolean GENERATED ALWAYS AS (disqualifiedByOrganizer OR  misPunch OR  notStart OR  notFinish OR  badCheck OR  overTime OR notCompeting) STORED,
 	disqualifiedByOrganizer boolean NOT NULL DEFAULT false,
@@ -163,6 +165,8 @@ COMMENT ON COLUMN {{eventId}}.runs.startTimeMs IS 'in miliseconds';
 COMMENT ON COLUMN {{eventId}}.runs.finishTimeMs IS 'in miliseconds';
 COMMENT ON COLUMN {{eventId}}.runs.penaltyTimeMs IS 'in miliseconds';
 COMMENT ON COLUMN {{eventId}}.runs.timeMs IS 'in miliseconds';
+COMMENT ON COLUMN {{eventId}}.runs.startGateTime IS 'DateTime when competitor crossed start photocell';
+COMMENT ON COLUMN {{eventId}}.runs.finishGateTime IS 'DateTime when competitor crossed finish photocell';
 COMMENT ON COLUMN {{eventId}}.runs.isRunning IS 'Competitor is running in this stage';
 COMMENT ON COLUMN {{eventId}}.runs.disqualifiedByOrganizer IS 'Competitor is disqualified by organizer for breaking rules, etc.';
 COMMENT ON COLUMN {{eventId}}.runs.notCompeting IS 'Competitor does run in this stage but not competing';
@@ -311,4 +315,4 @@ COMMENT ON COLUMN {{eventId}}.qxchanges.orig_data IS 'Store data overriden by ch
 ;
 -- insert into table: {{eventId}}.config;
 INSERT INTO {{eventId}}.config (ckey, cname, cvalue, ctype) VALUES 
-('db.version', 'Data version', '30500', 'int');
+('db.version', 'Data version', '30600', 'int');

--- a/quickevent/app/quickevent/plugins/Event/sql/create_db_sqlite.sql
+++ b/quickevent/app/quickevent/plugins/Event/sql/create_db_sqlite.sql
@@ -145,6 +145,8 @@ CREATE TABLE runs (
 	finishTimeMs integer,
 	penaltyTimeMs integer,
 	timeMs integer,
+	startGateTime timestamp,
+	finishGateTime timestamp,
 	isRunning boolean NOT NULL DEFAULT 1,
 	disqualified boolean GENERATED ALWAYS AS (disqualifiedByOrganizer OR  misPunch OR  notStart OR  notFinish OR  badCheck OR  overTime OR notCompeting) STORED,
 	disqualifiedByOrganizer boolean NOT NULL DEFAULT 0,
@@ -174,6 +176,10 @@ CREATE INDEX runs_ix3 ON runs (stageId, siId);
 -- COMMENT ON COLUMN runs.penaltyTimeMs IS 'in miliseconds';
 -- comments not suported for driver: SQLITE
 -- COMMENT ON COLUMN runs.timeMs IS 'in miliseconds';
+-- comments not suported for driver: SQLITE
+-- COMMENT ON COLUMN runs.startGateTime IS 'DateTime when competitor crossed start photocell';
+-- comments not suported for driver: SQLITE
+-- COMMENT ON COLUMN runs.finishGateTime IS 'DateTime when competitor crossed finish photocell';
 -- comments not suported for driver: SQLITE
 -- COMMENT ON COLUMN runs.isRunning IS 'Competitor is running in this stage';
 -- comments not suported for driver: SQLITE
@@ -339,4 +345,4 @@ CREATE TABLE qxchanges (
 ;
 -- insert into table: config;
 INSERT INTO config (ckey, cname, cvalue, ctype) VALUES 
-('db.version', 'Data version', '30500', 'int');
+('db.version', 'Data version', '30600', 'int');

--- a/quickevent/app/quickevent/plugins/Event/src/appdbconfig.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/appdbconfig.cpp
@@ -3,7 +3,6 @@
 #include "eventplugin.h"
 #include "eventconfig.h"
 
-#include <qcontainerfwd.h>
 #include <qf/core/assert.h>
 #include <qf/core/utils.h>
 #include <qf/core/sql/connection.h>
@@ -25,6 +24,7 @@ constexpr auto STAGE = "stage";
 constexpr auto RECEIPTS = "receipts";
 constexpr auto OFEED = "ofeed";
 constexpr auto ORESULTS = "oresults";
+constexpr auto RADIO_SENDER = "radioSender";
 constexpr auto QX = "qx";
 
 QVariantMap changedValues(const QVariantMap &old_values, const QVariantMap &new_values)
@@ -84,7 +84,7 @@ void AppDbConfig::load()
 			QString type = q.value(2).toString();
 			QVariant v = qf::core::Utils::retypeStringValue(val.toString(), type);
 			const auto group = key.section('.', 0, 0);
-			if (group == EVENT || group == QX) {
+			if (group == EVENT || group == QX || group == RADIO_SENDER) {
 				set_group_value(group, key.section('.', 1), v);
 			} else if (group == STAGE || group == RECEIPTS || group == ORESULTS || group == OFEED) {
 				auto stage_id = key.section('.', 1, 1).toInt();
@@ -99,6 +99,7 @@ void AppDbConfig::load()
 	Q_ASSERT(m_dbVersion > 0);
 
 	m_qxConfig = QxConfig::fromVariantMap(config.value(QX).toMap());
+	m_radioSenderConfig = services::RadioSenderConfig::fromVariantMap(config.value(RADIO_SENDER).toMap());
 	m_eventConfig = EventConfig::fromVariantMap(config.value(EVENT).toMap());
 
 	const auto load_stage_config = [&config](const QString &group, auto &target, auto fromVariantMap) {
@@ -167,6 +168,13 @@ void AppDbConfig::save(const QString &prefix, const QVariantMap &data)
 			q_ins.exec(qf::core::Exception::Throw);
 		}
 	}
+}
+
+void AppDbConfig::setRadioSenderConfig(const services::RadioSenderConfig &config)
+{
+	const QVariantMap changed_values = changedValues(m_radioSenderConfig.toVariantMap(), config.toVariantMap());
+	m_radioSenderConfig = config;
+	save(RADIO_SENDER, changed_values);
 }
 
 void AppDbConfig::setEventConfig(const EventConfig &config)

--- a/quickevent/app/quickevent/plugins/Event/src/appdbconfig.h
+++ b/quickevent/app/quickevent/plugins/Event/src/appdbconfig.h
@@ -4,13 +4,13 @@
 #include "plugins/Event/src/stageconfig.h"
 #include "services/oresultsconfig.h"
 #include "services/ofeed/ofeedconfig.h"
+#include "services/radiosender/radiosenderconfig.h"
 #include <plugins/Receipts/src/receiptsconfig.h>
 
 #include <QDateTime>
 #include <QObject>
 #include <QSet>
 #include <QVariantMap>
-#include <qcontainerfwd.h>
 
 namespace Event {
 
@@ -39,6 +39,8 @@ public:
 	void setReceiptsConfig(int stage_id, const Receipts::ReceiptsConfig &config);
 	const services::OFeedConfig &ofeedConfig(int stage_id) const;
 	void setOfeedConfig(int stage_id, const services::OFeedConfig &config);
+	const services::RadioSenderConfig &radioSenderConfig() const { return m_radioSenderConfig; }
+	void setRadioSenderConfig(const services::RadioSenderConfig &config);
 	const QxConfig &qxConfig() const { return m_qxConfig; }
 	void setQxConfig(const QxConfig &config);
 
@@ -53,6 +55,8 @@ private:
 	std::map<int, services::OResultsConfig> m_oresultsConfig;
 	EventConfig m_eventConfig;
 	QxConfig m_qxConfig;
+	services::RadioSenderConfig m_radioSenderConfig;
+
 	int m_dbVersion = 0;
 };
 

--- a/quickevent/app/quickevent/plugins/Event/src/eventconfig.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/eventconfig.cpp
@@ -42,7 +42,6 @@ EventConfig EventConfig::fromVariantMap(const QVariantMap &values)
 	data.importId = values.value("importId").toInt();
 	data.orisEventKey = values.value("orisEventKey").toString();
 	data.cardCheckTimeSec = values.value("cardChechCheckTimeSec").toInt();
-	data.oneTenthSecResults = values.value("oneTenthSecResults").toInt();
 	data.iofRace = values.value("iofRace").toBool();
 	data.iofXmlRaceNumber = values.value("iofXmlRaceNumber").toInt();
 	data.currentStageId = values.value("currentStageId", 1).toInt();
@@ -78,7 +77,6 @@ QVariantMap EventConfig::toVariantMap() const
 	values.insert("importId", importId);
 	values.insert("orisEventKey", orisEventKey);
 	values.insert("cardChechCheckTimeSec", cardCheckTimeSec);
-	values.insert("oneTenthSecResults", oneTenthSecResults);
 	values.insert("iofRace", iofRace);
 	values.insert("iofXmlRaceNumber", iofXmlRaceNumber);
 	values.insert("currentStageId", currentStageId);

--- a/quickevent/app/quickevent/plugins/Event/src/eventconfig.h
+++ b/quickevent/app/quickevent/plugins/Event/src/eventconfig.h
@@ -51,7 +51,6 @@ struct EventConfig
 	int importId = 0;
 	QString orisEventKey;
 	int cardCheckTimeSec = 0;
-	int oneTenthSecResults = 0;
 	bool iofRace = false;
 	int iofXmlRaceNumber = 0;
 	int currentStageId = 1;

--- a/quickevent/app/quickevent/plugins/Event/src/eventdialogwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/eventdialogwidget.cpp
@@ -43,8 +43,6 @@ EventDialogWidget::EventDialogWidget(QWidget *parent) :
 									 static_cast<int>(disc));
 	}
 
-	ui->ed_oneTenthSecResults->setDisabled(true);
-
 	QRegularExpression rx("[a-z][a-z0-9_]*"); // PostgreSQL schema must start with small letter and it may contain small letters, digits and underscores only.
 	QValidator *validator = new QRegularExpressionValidator(rx, this);
 	ui->ed_eventId->setValidator(validator);
@@ -130,7 +128,6 @@ void EventDialogWidget::loadParams(const EventDialogWidget::Params &params)
 	ui->ed_orisRace->setChecked(params.eventConfig.importId > 0);
 	ui->ed_orisEventKey->setText(params.eventConfig.orisEventKey);
 	ui->ed_cardChecCheckTimeSec->setValue(params.eventConfig.cardCheckTimeSec);
-	ui->ed_oneTenthSecResults->setCurrentIndex(params.eventConfig.oneTenthSecResults);
 	ui->ed_iofRace->setChecked(params.eventConfig.iofRace);
 	ui->ed_xmlRaceNumber->setValue(params.eventConfig.iofXmlRaceNumber);
 }
@@ -161,7 +158,6 @@ EventDialogWidget::Params EventDialogWidget::saveParams()
 	params.eventConfig.importId = ui->ed_orisImportId->text().toInt();
 	params.eventConfig.orisEventKey = ui->ed_orisEventKey->text();
 	params.eventConfig.cardCheckTimeSec = ui->ed_cardChecCheckTimeSec->value();
-	params.eventConfig.oneTenthSecResults = ui->ed_oneTenthSecResults->currentIndex();
 	params.eventConfig.iofRace = ui->ed_iofRace->isChecked();
 	params.eventConfig.iofXmlRaceNumber = ui->ed_xmlRaceNumber->value();
 	return params;

--- a/quickevent/app/quickevent/plugins/Event/src/eventdialogwidget.ui
+++ b/quickevent/app/quickevent/plugins/Event/src/eventdialogwidget.ui
@@ -69,20 +69,6 @@
      <item row="7" column="1">
       <widget class="QComboBox" name="cbxSportId"/>
      </item>
-     <item row="10" column="3">
-      <widget class="QComboBox" name="ed_oneTenthSecResults">
-       <item>
-        <property name="text">
-         <string>Disabled</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Enabled</string>
-        </property>
-       </item>
-      </widget>
-     </item>
      <item row="5" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
@@ -97,16 +83,6 @@
       <widget class="QLabel" name="label_14">
        <property name="text">
         <string>Card check</string>
-       </property>
-       <property name="buddy">
-        <cstring>ed_handicapLength</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="2">
-      <widget class="QLabel" name="label_15">
-       <property name="text">
-        <string>1/10 sec results</string>
        </property>
        <property name="buddy">
         <cstring>ed_handicapLength</cstring>
@@ -437,7 +413,6 @@
   <tabstop>ed_stageCount</tabstop>
   <tabstop>ed_handicapLength</tabstop>
   <tabstop>ed_cardChecCheckTimeSec</tabstop>
-  <tabstop>ed_oneTenthSecResults</tabstop>
   <tabstop>ed_iofRace</tabstop>
   <tabstop>ed_orisRace</tabstop>
   <tabstop>ed_orisImportId</tabstop>

--- a/quickevent/app/quickevent/plugins/Event/src/eventplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/eventplugin.cpp
@@ -15,6 +15,7 @@
 #include "services/emmaclient.h"
 #include "services/qx/qxclientservice.h"
 #include "services/punchingtest/punchingtestservice.h"
+#include "services/radiosender/radiosenderservice.h"
 
 #include <plugins/Core/src/widgets/settingsdialog.h>
 #include <plugins/Event/src/services/oresultsclient.h>
@@ -396,6 +397,9 @@ void EventPlugin::onInstalled()
 
 	auto shvapi_client = new services::qx::QxClientService(this);
 	services::Service::addService(shvapi_client);
+
+	auto *radio_sender = new services::RadioSenderService(this);
+	services::Service::addService(radio_sender);
 
 	auto *punching_test = new services::PunchingTestService(this);
 	services::Service::addService(punching_test);

--- a/quickevent/app/quickevent/plugins/Event/src/eventplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/eventplugin.cpp
@@ -265,19 +265,9 @@ int EventPlugin::stageIdForRun(int run_id) const
 
 int EventPlugin::stageStartMsec(int stage_id) const
 {
-	QTime start_time = stageStartTime(stage_id);
+	QTime start_time = stageStartDateTime(stage_id).time();
 	int ret = start_time.msecsSinceStartOfDay();
 	return ret;
-}
-
-QDate EventPlugin::stageStartDate(int stage_id) const
-{
-	return stageStartDateTime(stage_id).date();
-}
-
-QTime EventPlugin::stageStartTime(int stage_id) const
-{
-	return stageStartDateTime(stage_id).time();
 }
 
 QDateTime EventPlugin::stageStartDateTime(int stage_id) const
@@ -291,7 +281,7 @@ int EventPlugin::msecToStageStartAM(int si_am_time_sec, int msec, int stage_id) 
 		return quickevent::core::og::TimeMs::UNREAL_TIME_MSEC;
 	if(stage_id == 0)
 		stage_id = currentStageId();
-	int stage_start_msec = stageStartMsec(stage_id);
+	int stage_start_msec = stageStartDateTime(stage_id).time().msecsSinceStartOfDay();
 	int time_msec = quickevent::core::og::TimeMs::msecIntervalAM(stage_start_msec, (si_am_time_sec * 1000) + msec);
 	return time_msec;
 }

--- a/quickevent/app/quickevent/plugins/Event/src/eventplugin.h
+++ b/quickevent/app/quickevent/plugins/Event/src/eventplugin.h
@@ -76,8 +76,6 @@ public:
 	Q_INVOKABLE int stageIdForRun(int run_id) const;
 
 	int stageStartMsec(int stage_id) const;
-	QDate stageStartDate(int stage_id) const;
-	QTime stageStartTime(int stage_id) const;
 	QDateTime stageStartDateTime(int stage_id) const;
 	//Q_INVOKABLE int currentStageStartMsec();
 	int msecToStageStartAM(int si_am_time_sec, int msec = 0, int stage_id = 0) const;

--- a/quickevent/app/quickevent/plugins/Event/src/lentcardssettingspage.h
+++ b/quickevent/app/quickevent/plugins/Event/src/lentcardssettingspage.h
@@ -17,7 +17,7 @@ private:
 	using Super = Core::SettingsPage;
 
 public:
-	explicit LentCardsSettingsPage(QWidget *parent = 0);
+	explicit LentCardsSettingsPage(QWidget *parent = nullptr);
 	~LentCardsSettingsPage() override;
 protected:
 	void load() override;
@@ -27,4 +27,3 @@ private:
 	Ui::LentCardsSettingsPage *ui;
 	qf::gui::model::SqlTableModel *m_tableModel;
 };
-

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedclientwidget.cpp
@@ -412,7 +412,7 @@ void OFeedClientWidget::onBtTestConnectionClicked()
 			return;
 		}
 		widget_guard->m_isTestConnectionRunning = false;
-		widget_guard->ui->btTestConnection->setText(widget_guard->tr("Test connection"));
+		widget_guard->ui->btTestConnection->setText(OFeedClientWidget::tr("Test connection"));
 		widget_guard->ui->lbConnectionTestResult->setStyleSheet(success ? "color:#0a7a2f;" : "color:#b00020;");
 		widget_guard->ui->lbConnectionTestResult->setText(message);
 		widget_guard->updateTestConnectionState();

--- a/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedwelcomedialog.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/ofeed/ofeedwelcomedialog.cpp
@@ -5,13 +5,17 @@
 
 namespace Event::services {
 
-static QString docsBaseUrl()
+namespace {
+
+QString docsBaseUrl()
 {
 	const bool isCzech = QLocale().language() == QLocale::Czech;
 	return isCzech
 		? QStringLiteral("https://docs.orienteerfeed.com/cs")
 		: QStringLiteral("https://docs.orienteerfeed.com");
 }
+
+} // namespace
 
 OFeedWelcomeDialog::OFeedWelcomeDialog(QWidget *parent)
 	: Super(parent)

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderconfig.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderconfig.cpp
@@ -1,0 +1,30 @@
+#include "radiosenderconfig.h"
+
+namespace Event::services {
+
+RadioSenderConfig RadioSenderConfig::fromVariantMap(const QVariantMap &map)
+{
+	RadioSenderConfig config;
+	config.listenAddress = map.value(QStringLiteral("listenAddress"),
+		map.value(QStringLiteral("host"), config.listenAddress)).toString();
+	config.port = map.value(QStringLiteral("port"), config.port).toInt();
+	config.startControl = map.value(QStringLiteral("startControl"), config.startControl).toInt();
+	config.finishControl = map.value(QStringLiteral("finishControl"), config.finishControl).toInt();
+	config.startToleranceMs = map.value(QStringLiteral("startToleranceMs"), config.startToleranceMs).toInt();
+	config.finishToleranceMs = map.value(QStringLiteral("finishToleranceMs"), config.finishToleranceMs).toInt();
+	return config;
+}
+
+QVariantMap RadioSenderConfig::toVariantMap() const
+{
+	return {
+		{QStringLiteral("listenAddress"), listenAddress},
+		{QStringLiteral("port"), port},
+		{QStringLiteral("startControl"), startControl},
+		{QStringLiteral("finishControl"), finishControl},
+		{QStringLiteral("startToleranceMs"), startToleranceMs},
+		{QStringLiteral("finishToleranceMs"), finishToleranceMs},
+	};
+}
+
+} // namespace Event::services

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderconfig.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderconfig.h
@@ -12,8 +12,8 @@ struct RadioSenderConfig
 
 	QString listenAddress = QStringLiteral("0.0.0.0");
 	int port = 1122;
-	int startControl = 0;
-	int finishControl = 255;
+	int startControl = 11;
+	int finishControl = 901;
 	int startToleranceMs = 3000;
 	int finishToleranceMs = 2000;
 };

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderconfig.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderconfig.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QString>
+#include <QVariantMap>
+
+namespace Event::services {
+
+struct RadioSenderConfig
+{
+	static RadioSenderConfig fromVariantMap(const QVariantMap &map);
+	QVariantMap toVariantMap() const;
+
+	QString listenAddress = QStringLiteral("0.0.0.0");
+	int port = 1122;
+	int startControl = 0;
+	int finishControl = 255;
+	int startToleranceMs = 3000;
+	int finishToleranceMs = 2000;
+};
+
+} // namespace Event::services

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
@@ -117,7 +117,7 @@ void RadioSenderService::onReadyRead()
 void RadioSenderService::processLine(const QByteArray &line)
 {
     // {Control};{Type};{Bib};{Time:HH:mm:ss.fff};{Status};{Cancellation}
-    enum { ColControl = 0, ColType, ColBib, ColTime, ColStatus, ColCancellation };
+    enum { ColControl = 0, ColBib, ColTime, ColStatus, ColCancellation };
 	const QList<QByteArray> fields = line.split(';');
 	bool id_ok = false;
 	bool control_ok = false;

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
@@ -4,6 +4,8 @@
 
 #include "../../eventplugin.h"
 
+#include <plugins/Runs/src/runsplugin.h>
+
 #include <quickevent/core/si/checkedcard.h>
 
 #include <qf/core/log.h>
@@ -14,8 +16,6 @@
 #include <QTcpServer>
 #include <QTcpSocket>
 
-#include <cmath>
-
 using qf::gui::framework::getPlugin;
 
 namespace Event::services {
@@ -25,8 +25,6 @@ RadioSenderService::RadioSenderService(QObject *parent)
 {
 	m_server = new QTcpServer(this);
 	connect(m_server, &QTcpServer::newConnection, this, &RadioSenderService::onNewConnection);
-	connect(getPlugin<EventPlugin>(), &EventPlugin::dbEventNotify,
-		this, &RadioSenderService::onDbEventNotify, Qt::QueuedConnection);
 }
 
 QString RadioSenderService::serviceName()
@@ -186,49 +184,7 @@ void RadioSenderService::processLine(const QByteArray &line)
 	}
 
 	qf::gui::framework::Application::instance()->updateDbRecord( QStringLiteral("runs"), run_id, record, this);
-	updateRunTime(run_id);
-}
-
-void RadioSenderService::updateRunTime(int run_id)
-{
-	auto *event_plugin = getPlugin<EventPlugin>();
-	qf::core::sql::Query q;
-	q.prepare(QStringLiteral("SELECT stageId, startTimeMs, finishTimeMs, startGateTime, finishGateTime FROM runs WHERE id=:id"));
-	q.bindValue(QStringLiteral(":id"), run_id);
-	q.exec(qf::core::Exception::Throw);
-	if (!q.next() || q.value(QStringLiteral("finishTimeMs")).isNull())
-		return;
-
-	const int stage_id = q.value(QStringLiteral("stageId")).toInt();
-	const QDateTime stage_start = event_plugin->stageStartDateTime(stage_id);
-	const qint64 start_time = q.value(QStringLiteral("startTimeMs")).toLongLong();
-	const qint64 finish_time = q.value(QStringLiteral("finishTimeMs")).toLongLong();
-	const QVariant start_gate_value = q.value(QStringLiteral("startGateTime"));
-	const QVariant finish_gate_value = q.value(QStringLiteral("finishGateTime"));
-	const qint64 start_gate = stage_start.msecsTo(start_gate_value.toDateTime());
-	const qint64 finish_gate = stage_start.msecsTo(finish_gate_value.toDateTime());
-	const auto &config = event_plugin->appDbConfig().radioSenderConfig();
-	const bool use_start_gate = !start_gate_value.isNull()
-		&& std::abs(start_gate - start_time) <= config.startToleranceMs;
-	const bool use_finish_gate = !finish_gate_value.isNull()
-		&& std::abs(finish_gate - finish_time) <= config.finishToleranceMs;
-	const qint64 result_time = (use_finish_gate ? finish_gate : finish_time)
-		- (use_start_gate ? start_gate : start_time);
-	if (result_time <= 0)
-		return;
-
-	qf::gui::framework::Application::instance()->updateDbRecord(
-		QStringLiteral("runs"), run_id, {{QStringLiteral("timeMs"), result_time}}, this);
-}
-
-void RadioSenderService::onDbEventNotify(const QString &domain, int connection_id, const QVariant &data)
-{
-	Q_UNUSED(connection_id)
-	if (domain != QLatin1String(EventPlugin::DBEVENT_CARD_PROCESSED_AND_ASSIGNED))
-		return;
-	const quickevent::core::si::CheckedCard card(data.toMap());
-	if (card.runId() > 0)
-		updateRunTime(card.runId());
+	getPlugin<Runs::RunsPlugin>()->computeStageTime(run_id);
 }
 
 } // namespace Event::services

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
@@ -198,7 +198,7 @@ void RadioSenderService::updateRunTime(int run_id)
 	const QVariant finish_gate_value = q.value(QStringLiteral("finishGateTime"));
 	const qint64 start_gate = stage_start.msecsTo(start_gate_value.toDateTime());
 	const qint64 finish_gate = stage_start.msecsTo(finish_gate_value.toDateTime());
-	const auto config = event_plugin->appDbConfig().radioSenderConfig();
+	const auto &config = event_plugin->appDbConfig().radioSenderConfig();
 	const bool use_start_gate = !start_gate_value.isNull()
 		&& std::abs(start_gate - start_time) <= config.startToleranceMs;
 	const bool use_finish_gate = !finish_gate_value.isNull()

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
@@ -6,6 +6,7 @@
 
 #include <plugins/Runs/src/runsplugin.h>
 
+#include <qabstractsocket.h>
 #include <quickevent/core/si/checkedcard.h>
 
 #include <qf/core/log.h>
@@ -80,18 +81,22 @@ void RadioSenderService::onNewConnection()
 {
 	while (m_server->hasPendingConnections()) {
 		QTcpSocket *socket = m_server->nextPendingConnection();
+		qfInfo() << "New connection from" << socket->peerAddress().toString();
 		m_clients.insert(socket, {});
 		connect(socket, &QTcpSocket::readyRead, this, &RadioSenderService::onReadyRead);
 		connect(socket, &QTcpSocket::disconnected, this, [this, socket] {
 			m_clients.remove(socket);
 			socket->deleteLater();
-			setStatusMessage(tr("Listening, %1 sender(s) connected").arg(m_clients.size()));
 		});
-		connect(socket, &QTcpSocket::errorOccurred, this, [socket](QAbstractSocket::SocketError) {
-			qfWarning() << "RadioSender socket error:" << socket->errorString();
+		connect(socket, &QTcpSocket::errorOccurred, this, [socket](QAbstractSocket::SocketError error) {
+			if (error == QAbstractSocket::SocketError::RemoteHostClosedError) {
+				qfInfo() << "Remote host" << socket->peerAddress().toString() << "closed connection";
+			} else {
+				qfWarning() << "RadioSender socket error:" << socket->errorString();
+			}
 		});
-		setStatusMessage(tr("Listening, %1 sender(s) connected").arg(m_clients.size()));
 	}
+	setStatusMessage(tr("Listening, %1 sender(s) connected").arg(m_clients.size()));
 }
 
 void RadioSenderService::onReadyRead()
@@ -114,7 +119,7 @@ void RadioSenderService::onReadyRead()
 
 void RadioSenderService::processLine(const QByteArray &line)
 {
-    // {Control};{Type};{Bib};{Time:HH:mm:ss.fff};{Status};{Cancellation}
+    // {Control};{Bib};{Time:HH:mm:ss.fff};{Status};{Cancellation}
     enum { ColControl = 0, ColBib, ColTime, ColStatus, ColCancellation };
 	const QList<QByteArray> fields = line.split(';');
 	bool id_ok = false;

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
@@ -61,7 +61,7 @@ void RadioSenderService::stop()
 
 qf::gui::framework::DialogWidget *RadioSenderService::createDetailWidget()
 {
-	return new RadioSenderServiceWidget();
+	return new RadioSenderServiceWidget(this);
 }
 
 void RadioSenderService::startServer()

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
@@ -1,0 +1,225 @@
+#include "radiosenderservice.h"
+#include "radiosenderservicewidget.h"
+#include "radiosenderconfig.h"
+
+#include "../../eventplugin.h"
+
+#include <quickevent/core/si/checkedcard.h>
+
+#include <qf/core/log.h>
+#include <qf/core/sql/query.h>
+#include <qf/gui/framework/application.h>
+#include <qf/gui/framework/mainwindow.h>
+
+#include <QTcpServer>
+#include <QTcpSocket>
+
+#include <cmath>
+
+using qf::gui::framework::getPlugin;
+
+namespace Event::services {
+
+
+
+RadioSenderService::RadioSenderService(QObject *parent)
+	: Super(serviceName(), parent)
+{
+	m_server = new QTcpServer(this);
+	connect(m_server, &QTcpServer::newConnection, this, &RadioSenderService::onNewConnection);
+	connect(getPlugin<EventPlugin>(), &EventPlugin::dbEventNotify,
+		this, &RadioSenderService::onDbEventNotify, Qt::QueuedConnection);
+}
+
+QString RadioSenderService::serviceName()
+{
+	return QStringLiteral("RadioSender");
+}
+
+QString RadioSenderService::serviceDisplayName() const
+{
+	return tr("Radio Sender");
+}
+
+void RadioSenderService::run()
+{
+	startServer();
+	if (m_server->isListening())
+		Super::run();
+}
+
+void RadioSenderService::stop()
+{
+	m_server->close();
+	for (QTcpSocket *socket : m_clients.keys()) {
+		socket->disconnectFromHost();
+		socket->deleteLater();
+	}
+	m_clients.clear();
+	Super::stop();
+}
+
+qf::gui::framework::DialogWidget *RadioSenderService::createDetailWidget()
+{
+	return new RadioSenderServiceWidget();
+}
+
+void RadioSenderService::startServer()
+{
+	const auto config = getPlugin<EventPlugin>()->appDbConfig().radioSenderConfig();
+	const QHostAddress address(config.listenAddress);
+	if (address.isNull() || config.port <= 0 || config.port > 65535) {
+		setStatusMessage(tr("Invalid listen address or port"));
+		return;
+	}
+	if (!m_server->listen(address, static_cast<quint16>(config.port))) {
+		setStatusMessage(tr("Cannot listen on %1:%2: %3")
+			.arg(config.listenAddress).arg(config.port).arg(m_server->errorString()));
+		return;
+	}
+	setStatusMessage(tr("Listening on %1:%2").arg(config.listenAddress).arg(config.port));
+}
+
+void RadioSenderService::onNewConnection()
+{
+	while (m_server->hasPendingConnections()) {
+		QTcpSocket *socket = m_server->nextPendingConnection();
+		m_clients.insert(socket, {});
+		connect(socket, &QTcpSocket::readyRead, this, &RadioSenderService::onReadyRead);
+		connect(socket, &QTcpSocket::disconnected, this, [this, socket] {
+			m_clients.remove(socket);
+			socket->deleteLater();
+			setStatusMessage(tr("Listening, %1 sender(s) connected").arg(m_clients.size()));
+		});
+		connect(socket, &QTcpSocket::errorOccurred, this, [socket](QAbstractSocket::SocketError) {
+			qfWarning() << "RadioSender socket error:" << socket->errorString();
+		});
+		setStatusMessage(tr("Listening, %1 sender(s) connected").arg(m_clients.size()));
+	}
+}
+
+void RadioSenderService::onReadyRead()
+{
+	auto *socket = qobject_cast<QTcpSocket*>(sender());
+	if (!socket || !m_clients.contains(socket))
+		return;
+	QByteArray &buffer = m_clients[socket];
+	buffer += socket->readAll();
+	while (true) {
+		const qsizetype eol = buffer.indexOf('\n');
+		if (eol < 0)
+			break;
+		const QByteArray line = buffer.left(eol).trimmed();
+		buffer.remove(0, eol + 1);
+		if (!line.isEmpty())
+			processLine(line);
+	}
+}
+
+void RadioSenderService::processLine(const QByteArray &line)
+{
+	const QList<QByteArray> fields = line.split(';');
+	bool id_ok = false;
+	bool control_ok = false;
+	const int competitor_id = fields.value(0).toInt(&id_ok);
+	const int control = fields.value(1).toInt(&control_ok);
+	const QTime time = QTime::fromString(QString::fromLatin1(fields.value(2)), QStringLiteral("HH:mm:ss,zzz"));
+	const auto config = getPlugin<EventPlugin>()->appDbConfig().radioSenderConfig();
+	const bool valid = fields.size() == 3 && id_ok && control_ok && time.isValid()
+		&& config.startControl != config.finishControl
+		&& (control == config.startControl || control == config.finishControl);
+	QString parsed_data;
+	if (valid) {
+		parsed_data = QStringLiteral("competitorId=%1, control=%2 (%3), time=%4")
+			.arg(competitor_id)
+			.arg(control)
+			.arg(control == config.startControl ? QStringLiteral("start") : QStringLiteral("finish"))
+			.arg(time.toString(QStringLiteral("HH:mm:ss.zzz")));
+	} else {
+		parsed_data = QStringLiteral("invalid message");
+	}
+	m_receivedLineLog.append(QStringLiteral("%1\n  %2")
+		.arg(QString::fromUtf8(line), parsed_data));
+	while (m_receivedLineLog.size() > 20)
+		m_receivedLineLog.removeFirst();
+	emit receivedLineLogged();
+	if (!valid) {
+		qfWarning() << "RadioSender: invalid message:" << line;
+		return;
+	}
+
+	auto *event_plugin = getPlugin<EventPlugin>();
+	const int stage_id = event_plugin->currentStageId();
+	qf::core::sql::Query q;
+	q.prepare(QStringLiteral(
+		"SELECT runs.id FROM runs JOIN competitors ON competitors.id=runs.competitorId"
+		" WHERE runs.stageId=:stageId AND runs.isRunning"
+		" AND (competitors.startNumber=:competitorId OR runs.siId=:competitorId)"));
+	q.bindValue(QStringLiteral(":stageId"), stage_id);
+	q.bindValue(QStringLiteral(":competitorId"), competitor_id);
+	q.exec(qf::core::Exception::Throw);
+	if (!q.next()) {
+		qfWarning() << "RadioSender: competitor not found:" << competitor_id;
+		return;
+	}
+	const int run_id = q.value(0).toInt();
+	if (q.next()) {
+		qfWarning() << "RadioSender: ambiguous competitor id:" << competitor_id;
+		return;
+	}
+
+	QDateTime gate_time(event_plugin->stageStartDate(stage_id), time);
+	const QDateTime stage_start = event_plugin->stageStartDateTime(stage_id);
+	if (gate_time < stage_start.addSecs(-12 * 60 * 60))
+		gate_time = gate_time.addDays(1);
+
+	const QString field = control == config.startControl
+		? QStringLiteral("startGateTime") : QStringLiteral("finishGateTime");
+	qf::gui::framework::Application::instance()->updateDbRecord(
+		QStringLiteral("runs"), run_id, {{field, gate_time}}, this);
+	updateRunTime(run_id);
+}
+
+void RadioSenderService::updateRunTime(int run_id)
+{
+	auto *event_plugin = getPlugin<EventPlugin>();
+	qf::core::sql::Query q;
+	q.prepare(QStringLiteral("SELECT stageId, startTimeMs, finishTimeMs, startGateTime, finishGateTime FROM runs WHERE id=:id"));
+	q.bindValue(QStringLiteral(":id"), run_id);
+	q.exec(qf::core::Exception::Throw);
+	if (!q.next() || q.value(QStringLiteral("finishTimeMs")).isNull())
+		return;
+
+	const int stage_id = q.value(QStringLiteral("stageId")).toInt();
+	const QDateTime stage_start = event_plugin->stageStartDateTime(stage_id);
+	const qint64 start_time = q.value(QStringLiteral("startTimeMs")).toLongLong();
+	const qint64 finish_time = q.value(QStringLiteral("finishTimeMs")).toLongLong();
+	const QVariant start_gate_value = q.value(QStringLiteral("startGateTime"));
+	const QVariant finish_gate_value = q.value(QStringLiteral("finishGateTime"));
+	const qint64 start_gate = stage_start.msecsTo(start_gate_value.toDateTime());
+	const qint64 finish_gate = stage_start.msecsTo(finish_gate_value.toDateTime());
+	const auto config = event_plugin->appDbConfig().radioSenderConfig();
+	const bool use_start_gate = !start_gate_value.isNull()
+		&& std::abs(start_gate - start_time) <= config.startToleranceMs;
+	const bool use_finish_gate = !finish_gate_value.isNull()
+		&& std::abs(finish_gate - finish_time) <= config.finishToleranceMs;
+	const qint64 result_time = (use_finish_gate ? finish_gate : finish_time)
+		- (use_start_gate ? start_gate : start_time);
+	if (result_time <= 0)
+		return;
+
+	qf::gui::framework::Application::instance()->updateDbRecord(
+		QStringLiteral("runs"), run_id, {{QStringLiteral("timeMs"), result_time}}, this);
+}
+
+void RadioSenderService::onDbEventNotify(const QString &domain, int connection_id, const QVariant &data)
+{
+	Q_UNUSED(connection_id)
+	if (domain != QLatin1String(EventPlugin::DBEVENT_CARD_PROCESSED_AND_ASSIGNED))
+		return;
+	const quickevent::core::si::CheckedCard card(data.toMap());
+	if (card.runId() > 0)
+		updateRunTime(card.runId());
+}
+
+} // namespace Event::services

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
@@ -174,15 +174,15 @@ void RadioSenderService::processLine(const QByteArray &line)
 				? QStringLiteral("startGateTime")
 				: QStringLiteral("finishGateTime");
 	if (time.isValid()) {
-	    const QDateTime stage_start = event_plugin->stageStartDateTime(stage_id);
-	    QDateTime gate_time(stage_start.date(), time);
-	    record[field] = gate_time;
+		const QDateTime stage_start = event_plugin->stageStartDateTime(stage_id);
+		QDateTime gate_time(stage_start.date(), time);
+		record[field] = gate_time;
 	}
 	if (is_dns) {
 		record[QStringLiteral("notstart")] = true;
 	}
 	if (is_cancellation) {
-	    record[field] = {};
+		record[field] = {};
 	}
 
 	qf::gui::framework::Application::instance()->updateDbRecord( QStringLiteral("runs"), run_id, record, this);

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.cpp
@@ -20,8 +20,6 @@ using qf::gui::framework::getPlugin;
 
 namespace Event::services {
 
-
-
 RadioSenderService::RadioSenderService(QObject *parent)
 	: Super(serviceName(), parent)
 {
@@ -118,32 +116,35 @@ void RadioSenderService::onReadyRead()
 
 void RadioSenderService::processLine(const QByteArray &line)
 {
+    // {Control};{Type};{Bib};{Time:HH:mm:ss.fff};{Status};{Cancellation}
+    enum { ColControl = 0, ColType, ColBib, ColTime, ColStatus, ColCancellation };
 	const QList<QByteArray> fields = line.split(';');
 	bool id_ok = false;
 	bool control_ok = false;
-	const int competitor_id = fields.value(0).toInt(&id_ok);
-	const int control = fields.value(1).toInt(&control_ok);
-	const QTime time = QTime::fromString(QString::fromLatin1(fields.value(2)), QStringLiteral("HH:mm:ss,zzz"));
+	const int start_number = fields.value(ColBib).trimmed().toInt(&id_ok);
+	const int control = fields.value(ColControl).trimmed().toInt(&control_ok);
+	const QTime time = QTime::fromString(QString::fromLatin1(fields.value(ColTime).trimmed()), QStringLiteral("HH:mm:ss.zzz"));
+	bool is_dns = fields.value(ColStatus).trimmed() == "DNS";
+	bool is_cancellation = fields.value(ColCancellation).trimmed() == "ANN";
 	const auto config = getPlugin<EventPlugin>()->appDbConfig().radioSenderConfig();
-	const bool valid = fields.size() == 3 && id_ok && control_ok && time.isValid()
-		&& config.startControl != config.finishControl
-		&& (control == config.startControl || control == config.finishControl);
+	const bool is_valid = (control == config.startControl || control == config.finishControl)
+		&& (time.isValid() || is_cancellation || is_dns);
 	QString parsed_data;
-	if (valid) {
-		parsed_data = QStringLiteral("competitorId=%1, control=%2 (%3), time=%4")
-			.arg(competitor_id)
-			.arg(control)
-			.arg(control == config.startControl ? QStringLiteral("start") : QStringLiteral("finish"))
+	if (is_valid) {
+		parsed_data = QStringLiteral("%1, startNumber: %2, time=%3")
+			.arg(control == config.startControl ? QStringLiteral("STA") : QStringLiteral("FIN"))
+			.arg(start_number)
 			.arg(time.toString(QStringLiteral("HH:mm:ss.zzz")));
 	} else {
 		parsed_data = QStringLiteral("invalid message");
 	}
 	m_receivedLineLog.append(QStringLiteral("%1\n  %2")
 		.arg(QString::fromUtf8(line), parsed_data));
-	while (m_receivedLineLog.size() > 20)
+	while (m_receivedLineLog.size() > 20) {
 		m_receivedLineLog.removeFirst();
+	}
 	emit receivedLineLogged();
-	if (!valid) {
+	if (!is_valid) {
 		qfWarning() << "RadioSender: invalid message:" << line;
 		return;
 	}
@@ -151,32 +152,40 @@ void RadioSenderService::processLine(const QByteArray &line)
 	auto *event_plugin = getPlugin<EventPlugin>();
 	const int stage_id = event_plugin->currentStageId();
 	qf::core::sql::Query q;
-	q.prepare(QStringLiteral(
-		"SELECT runs.id FROM runs JOIN competitors ON competitors.id=runs.competitorId"
-		" WHERE runs.stageId=:stageId AND runs.isRunning"
-		" AND (competitors.startNumber=:competitorId OR runs.siId=:competitorId)"));
+	q.prepare("SELECT runs.id FROM runs JOIN competitors ON competitors.id=runs.competitorId"
+		" WHERE runs.stageId=:stageId"
+		" AND runs.isRunning"
+		" AND competitors.startNumber=:startNumber");
 	q.bindValue(QStringLiteral(":stageId"), stage_id);
-	q.bindValue(QStringLiteral(":competitorId"), competitor_id);
+	q.bindValue(QStringLiteral(":startNumber"), start_number);
 	q.exec(qf::core::Exception::Throw);
 	if (!q.next()) {
-		qfWarning() << "RadioSender: competitor not found:" << competitor_id;
+		qfWarning() << "RadioSender: competitor not found:" << start_number;
 		return;
 	}
 	const int run_id = q.value(0).toInt();
 	if (q.next()) {
-		qfWarning() << "RadioSender: ambiguous competitor id:" << competitor_id;
+		qfWarning() << "RadioSender: ambiguous competitor id:" << start_number;
 		return;
 	}
 
-	QDateTime gate_time(event_plugin->stageStartDate(stage_id), time);
-	const QDateTime stage_start = event_plugin->stageStartDateTime(stage_id);
-	if (gate_time < stage_start.addSecs(-12 * 60 * 60))
-		gate_time = gate_time.addDays(1);
-
+	QVariantMap record;
 	const QString field = control == config.startControl
-		? QStringLiteral("startGateTime") : QStringLiteral("finishGateTime");
-	qf::gui::framework::Application::instance()->updateDbRecord(
-		QStringLiteral("runs"), run_id, {{field, gate_time}}, this);
+				? QStringLiteral("startGateTime")
+				: QStringLiteral("finishGateTime");
+	if (time.isValid()) {
+	    const QDateTime stage_start = event_plugin->stageStartDateTime(stage_id);
+	    QDateTime gate_time(stage_start.date(), time);
+	    record[field] = gate_time;
+	}
+	if (is_dns) {
+		record[QStringLiteral("notstart")] = true;
+	}
+	if (is_cancellation) {
+	    record[field] = {};
+	}
+
+	qf::gui::framework::Application::instance()->updateDbRecord( QStringLiteral("runs"), run_id, record, this);
 	updateRunTime(run_id);
 }
 

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.h
@@ -23,8 +23,7 @@ public:
 	QString serviceDisplayName() const override;
 	const QStringList &receivedLineLog() const { return m_receivedLineLog; }
 
-signals:
-	void receivedLineLogged();
+	Q_SIGNAL void receivedLineLogged();
 
 private:
 	qf::gui::framework::DialogWidget *createDetailWidget() override;

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "../service.h"
+
+#include <QStringList>
+
+class QTcpServer;
+class QTcpSocket;
+
+namespace Event::services {
+
+class RadioSenderService : public Service
+{
+	Q_OBJECT
+	using Super = Service;
+public:
+	explicit RadioSenderService(QObject *parent);
+
+	void run() override;
+	void stop() override;
+
+	static QString serviceName();
+	QString serviceDisplayName() const override;
+	const QStringList &receivedLineLog() const { return m_receivedLineLog; }
+
+signals:
+	void receivedLineLogged();
+
+private:
+	qf::gui::framework::DialogWidget *createDetailWidget() override;
+	void startServer();
+	void onNewConnection();
+	void onReadyRead();
+	void processLine(const QByteArray &line);
+	void updateRunTime(int run_id);
+	void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
+
+	QTcpServer *m_server = nullptr;
+	QHash<QTcpSocket*, QByteArray> m_clients;
+	QStringList m_receivedLineLog;
+};
+
+} // namespace Event::services

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.h
@@ -25,12 +25,12 @@ public:
 
 	Q_SIGNAL void receivedLineLogged();
 
+	void processLine(const QByteArray &line);
 private:
 	qf::gui::framework::DialogWidget *createDetailWidget() override;
 	void startServer();
 	void onNewConnection();
 	void onReadyRead();
-	void processLine(const QByteArray &line);
 	void updateRunTime(int run_id);
 	void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
 

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservice.h
@@ -31,8 +31,6 @@ private:
 	void startServer();
 	void onNewConnection();
 	void onReadyRead();
-	void updateRunTime(int run_id);
-	void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
 
 	QTcpServer *m_server = nullptr;
 	QHash<QTcpSocket*, QByteArray> m_clients;

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp
@@ -79,7 +79,7 @@ void RadioSenderServiceWidget::updateServiceControls()
 
 void RadioSenderServiceWidget::updateReceivedLineLog()
 {
-	ui->edReceivedLines->setPlainText(m_service->receivedLineLog().join(QStringLiteral("\n\n")));
+	ui->edReceivedLines->setPlainText(m_service->receivedLineLog().join(QStringLiteral("\n")));
 }
 
 void RadioSenderServiceWidget::saveConfig()

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp
@@ -4,6 +4,7 @@
 
 #include "../../eventplugin.h"
 
+#include <qf/core/assert.h>
 #include <qf/gui/framework/mainwindow.h>
 
 #include <QDialog>
@@ -12,10 +13,12 @@ using qf::gui::framework::getPlugin;
 
 namespace Event::services {
 
-RadioSenderServiceWidget::RadioSenderServiceWidget(QWidget *parent)
+RadioSenderServiceWidget::RadioSenderServiceWidget(RadioSenderService *service, QWidget *parent)
 	: Super(parent)
 	, ui(new Ui::RadioSenderServiceWidget)
+	, m_service(service)
 {
+	Q_ASSERT(m_service);
 	setPersistentSettingsId(QStringLiteral("RadioSenderServiceWidget"));
 	ui->setupUi(this);
 	auto *event_plugin = getPlugin<EventPlugin>();
@@ -27,12 +30,14 @@ RadioSenderServiceWidget::RadioSenderServiceWidget(QWidget *parent)
 	ui->edStartTolerance->setValue(config.startToleranceMs);
 	ui->edFinishTolerance->setValue(config.finishToleranceMs);
 
-	m_service = qobject_cast<RadioSenderService*>(Service::serviceByName(RadioSenderService::serviceName()));
-	if (m_service) {
-		connect(m_service, &RadioSenderService::receivedLineLogged,
-			this, &RadioSenderServiceWidget::updateReceivedLineLog);
-		updateReceivedLineLog();
-	}
+	connect(m_service, &RadioSenderService::receivedLineLogged,
+		this, &RadioSenderServiceWidget::updateReceivedLineLog);
+	connect(m_service, &RadioSenderService::statusChanged,
+		this, &RadioSenderServiceWidget::updateServiceControls);
+	connect(ui->btStart, &QPushButton::clicked, this, [this] { m_service->setRunning(true); });
+	connect(ui->btStop, &QPushButton::clicked, this, [this] { m_service->setRunning(false); });
+	updateReceivedLineLog();
+	updateServiceControls();
 }
 
 RadioSenderServiceWidget::~RadioSenderServiceWidget()
@@ -47,10 +52,16 @@ bool RadioSenderServiceWidget::acceptDialogDone(int result)
 	return true;
 }
 
+void RadioSenderServiceWidget::updateServiceControls()
+{
+	const bool running = m_service->isRunning();
+	ui->btStart->setEnabled(!running);
+	ui->btStop->setEnabled(running);
+}
+
 void RadioSenderServiceWidget::updateReceivedLineLog()
 {
-	if (m_service)
-		ui->edReceivedLines->setPlainText(m_service->receivedLineLog().join(QStringLiteral("\n\n")));
+	ui->edReceivedLines->setPlainText(m_service->receivedLineLog().join(QStringLiteral("\n\n")));
 }
 
 void RadioSenderServiceWidget::saveConfig()
@@ -65,10 +76,9 @@ void RadioSenderServiceWidget::saveConfig()
 	config.finishToleranceMs = ui->edFinishTolerance->value();
 	event_plugin->appDbConfig().setRadioSenderConfig(config);
 
-	auto *service = qobject_cast<RadioSenderService*>(Service::serviceByName(RadioSenderService::serviceName()));
-	if (service && service->isRunning()) {
-		service->stop();
-		service->run();
+	if (m_service->isRunning()) {
+		m_service->stop();
+		m_service->run();
 	}
 }
 

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp
@@ -30,22 +30,24 @@ RadioSenderServiceWidget::RadioSenderServiceWidget(RadioSenderService *service, 
 	ui->edStartTolerance->setValue(config.startToleranceMs);
 	ui->edFinishTolerance->setValue(config.finishToleranceMs);
 
-	ui->edTestPunch->addItem("11;STA;1;09:34:02.714;;;");     // bib 1 start
-	ui->edTestPunch->addItem("901;FIN;1;09:34:08.892;;;");    // bib 1 finish
-	ui->edTestPunch->addItem("11;STA;2;09:41:06.986;;;");     // bib 2 start
-	ui->edTestPunch->addItem("11;STA;2;09:41:06.986;;ANN;");  // bib 2 start canceled
-	ui->edTestPunch->addItem("11;STA;3;09:41:06.986;;;");     // bib 3 start (note: with the time previously assigned to bib 2)
-	ui->edTestPunch->addItem("11;STA;2;09:41:30.323;DNS;;");  // bib 2 DNS (time represent when the DNS is recorded)
-	ui->edTestPunch->addItem("11;STA;4;09:41:38.751;DNS;;");  // bib 4 DNS
-	ui->edTestPunch->addItem("11;STA;4;09:41:38.751;;ANN;");  // bib 4 DNS canceled (note: DNS flag is not present, only the time)
-	ui->edTestPunch->addItem("11;STA;4;09:42:20.959;;;");     // bib 4 start
-	ui->edTestPunch->addItem("11;STA;4;09:42:20.959;;ANN;");  // bib 4 start canceled (note: the time is discarded not assigned to anyone else)
-	ui->edTestPunch->addItem("11;STA;4;09:42:36.161;;;");     // bib 4 start
-	ui->edTestPunch->addItem("901;FIN;3;09:42:40.677;;;");    // bib 3 finish
-	ui->edTestPunch->addItem("901;FIN;3;09:42:40.677;;ANN;"); // bib 3 finish canceled (note: the time is discarded)
-	ui->edTestPunch->addItem("901;FIN;3;09:42:50.739;;;");    // bib 3 finish
-	ui->edTestPunch->addItem("901;FIN;4;09:43:17.101;;;");    // bib 4 finish
-
+	ui->edTestPunch->addItem("11;1;09:34:02.714;;;");     // bib 1 start
+	ui->edTestPunch->addItem("901;FIN;1;09:34:08.892;;;");// bib 1 finish
+	ui->edTestPunch->addItem("11;2;09:41:06.986;;;");     // bib 2 start
+	ui->edTestPunch->addItem("11;2;09:41:06.986;;ANN;");  // bib 2 start canceled
+	ui->edTestPunch->addItem("11;3;09:41:06.986;;;");     // bib 3 start (note: with the time previously assigned to bib 2)
+	ui->edTestPunch->addItem("11;2;09:41:30.323;DNS;;");  // bib 2 DNS (time represent when the DNS is recorded)
+	ui->edTestPunch->addItem("11;4;09:41:38.751;DNS;;");  // bib 4 DNS
+	ui->edTestPunch->addItem("11;4;09:41:38.751;;ANN;");  // bib 4 DNS canceled (note: DNS flag is not present, only the time)
+	ui->edTestPunch->addItem("11;4;09:42:20.959;;;");     // bib 4 start
+	ui->edTestPunch->addItem("11;4;09:42:20.959;;ANN;");  // bib 4 start canceled (note: the time is discarded not assigned to anyone else)
+	ui->edTestPunch->addItem("11;4;09:42:36.161;;;");     // bib 4 start
+	ui->edTestPunch->addItem("901;3;09:42:40.677;;;");    // bib 3 finish
+	ui->edTestPunch->addItem("901;3;09:42:40.677;;ANN;"); // bib 3 finish canceled (note: the time is discarded)
+	ui->edTestPunch->addItem("901;3;09:42:50.739;;;");    // bib 3 finish
+	ui->edTestPunch->addItem("901;4;09:43:17.101;;;");    // bib 4 finish
+	connect(ui->btSendTestPunch, &QPushButton::clicked, this, [this] {
+		onTestPunch(ui->edTestPunch->currentText());
+	});
 	connect(m_service, &RadioSenderService::receivedLineLogged,
 		this, &RadioSenderServiceWidget::updateReceivedLineLog);
 	connect(m_service, &RadioSenderService::statusChanged,
@@ -96,6 +98,11 @@ void RadioSenderServiceWidget::saveConfig()
 		m_service->stop();
 		m_service->run();
 	}
+}
+
+void RadioSenderServiceWidget::onTestPunch(const QString &line)
+{
+	m_service->processLine(line.toUtf8());
 }
 
 } // namespace Event::services

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp
@@ -31,7 +31,7 @@ RadioSenderServiceWidget::RadioSenderServiceWidget(RadioSenderService *service, 
 	ui->edFinishTolerance->setValue(config.finishToleranceMs);
 
 	ui->edTestPunch->addItem("11;1;09:34:02.714;;;");     // bib 1 start
-	ui->edTestPunch->addItem("901;FIN;1;09:34:08.892;;;");// bib 1 finish
+	ui->edTestPunch->addItem("901;1;09:34:08.892;;;");// bib 1 finish
 	ui->edTestPunch->addItem("11;2;09:41:06.986;;;");     // bib 2 start
 	ui->edTestPunch->addItem("11;2;09:41:06.986;;ANN;");  // bib 2 start canceled
 	ui->edTestPunch->addItem("11;3;09:41:06.986;;;");     // bib 3 start (note: with the time previously assigned to bib 2)

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp
@@ -30,6 +30,22 @@ RadioSenderServiceWidget::RadioSenderServiceWidget(RadioSenderService *service, 
 	ui->edStartTolerance->setValue(config.startToleranceMs);
 	ui->edFinishTolerance->setValue(config.finishToleranceMs);
 
+	ui->edTestPunch->addItem("11;STA;1;09:34:02.714;;;");     // bib 1 start
+	ui->edTestPunch->addItem("901;FIN;1;09:34:08.892;;;");    // bib 1 finish
+	ui->edTestPunch->addItem("11;STA;2;09:41:06.986;;;");     // bib 2 start
+	ui->edTestPunch->addItem("11;STA;2;09:41:06.986;;ANN;");  // bib 2 start canceled
+	ui->edTestPunch->addItem("11;STA;3;09:41:06.986;;;");     // bib 3 start (note: with the time previously assigned to bib 2)
+	ui->edTestPunch->addItem("11;STA;2;09:41:30.323;DNS;;");  // bib 2 DNS (time represent when the DNS is recorded)
+	ui->edTestPunch->addItem("11;STA;4;09:41:38.751;DNS;;");  // bib 4 DNS
+	ui->edTestPunch->addItem("11;STA;4;09:41:38.751;;ANN;");  // bib 4 DNS canceled (note: DNS flag is not present, only the time)
+	ui->edTestPunch->addItem("11;STA;4;09:42:20.959;;;");     // bib 4 start
+	ui->edTestPunch->addItem("11;STA;4;09:42:20.959;;ANN;");  // bib 4 start canceled (note: the time is discarded not assigned to anyone else)
+	ui->edTestPunch->addItem("11;STA;4;09:42:36.161;;;");     // bib 4 start
+	ui->edTestPunch->addItem("901;FIN;3;09:42:40.677;;;");    // bib 3 finish
+	ui->edTestPunch->addItem("901;FIN;3;09:42:40.677;;ANN;"); // bib 3 finish canceled (note: the time is discarded)
+	ui->edTestPunch->addItem("901;FIN;3;09:42:50.739;;;");    // bib 3 finish
+	ui->edTestPunch->addItem("901;FIN;4;09:43:17.101;;;");    // bib 4 finish
+
 	connect(m_service, &RadioSenderService::receivedLineLogged,
 		this, &RadioSenderServiceWidget::updateReceivedLineLog);
 	connect(m_service, &RadioSenderService::statusChanged,

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.cpp
@@ -1,0 +1,75 @@
+#include "radiosenderservicewidget.h"
+#include "ui_radiosenderservicewidget.h"
+#include "radiosenderservice.h"
+
+#include "../../eventplugin.h"
+
+#include <qf/gui/framework/mainwindow.h>
+
+#include <QDialog>
+
+using qf::gui::framework::getPlugin;
+
+namespace Event::services {
+
+RadioSenderServiceWidget::RadioSenderServiceWidget(QWidget *parent)
+	: Super(parent)
+	, ui(new Ui::RadioSenderServiceWidget)
+{
+	setPersistentSettingsId(QStringLiteral("RadioSenderServiceWidget"));
+	ui->setupUi(this);
+	auto *event_plugin = getPlugin<EventPlugin>();
+	const auto config = event_plugin->appDbConfig().radioSenderConfig();
+	ui->edListenAddress->setText(config.listenAddress);
+	ui->edPort->setValue(config.port);
+	ui->edStartControl->setValue(config.startControl);
+	ui->edFinishControl->setValue(config.finishControl);
+	ui->edStartTolerance->setValue(config.startToleranceMs);
+	ui->edFinishTolerance->setValue(config.finishToleranceMs);
+
+	m_service = qobject_cast<RadioSenderService*>(Service::serviceByName(RadioSenderService::serviceName()));
+	if (m_service) {
+		connect(m_service, &RadioSenderService::receivedLineLogged,
+			this, &RadioSenderServiceWidget::updateReceivedLineLog);
+		updateReceivedLineLog();
+	}
+}
+
+RadioSenderServiceWidget::~RadioSenderServiceWidget()
+{
+	delete ui;
+}
+
+bool RadioSenderServiceWidget::acceptDialogDone(int result)
+{
+	if (result == QDialog::Accepted)
+		saveConfig();
+	return true;
+}
+
+void RadioSenderServiceWidget::updateReceivedLineLog()
+{
+	if (m_service)
+		ui->edReceivedLines->setPlainText(m_service->receivedLineLog().join(QStringLiteral("\n\n")));
+}
+
+void RadioSenderServiceWidget::saveConfig()
+{
+	auto *event_plugin = getPlugin<EventPlugin>();
+	auto config = event_plugin->appDbConfig().radioSenderConfig();
+	config.listenAddress = ui->edListenAddress->text().trimmed();
+	config.port = ui->edPort->value();
+	config.startControl = ui->edStartControl->value();
+	config.finishControl = ui->edFinishControl->value();
+	config.startToleranceMs = ui->edStartTolerance->value();
+	config.finishToleranceMs = ui->edFinishTolerance->value();
+	event_plugin->appDbConfig().setRadioSenderConfig(config);
+
+	auto *service = qobject_cast<RadioSenderService*>(Service::serviceByName(RadioSenderService::serviceName()));
+	if (service && service->isRunning()) {
+		service->stop();
+		service->run();
+	}
+}
+
+} // namespace Event::services

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <qf/gui/framework/dialogwidget.h>
+
+namespace Event::services {
+
+namespace Ui { class RadioSenderServiceWidget; }
+
+class RadioSenderServiceWidget : public qf::gui::framework::DialogWidget
+{
+	Q_OBJECT
+	using Super = qf::gui::framework::DialogWidget;
+public:
+	explicit RadioSenderServiceWidget(QWidget *parent = nullptr);
+	~RadioSenderServiceWidget() override;
+
+private:
+	bool acceptDialogDone(int result) override;
+	void saveConfig();
+	void updateReceivedLineLog();
+
+	Ui::RadioSenderServiceWidget *ui;
+	class RadioSenderService *m_service = nullptr;
+};
+
+} // namespace Event::services

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.h
@@ -6,21 +6,24 @@ namespace Event::services {
 
 namespace Ui { class RadioSenderServiceWidget; }
 
+class RadioSenderService;
+
 class RadioSenderServiceWidget : public qf::gui::framework::DialogWidget
 {
 	Q_OBJECT
 	using Super = qf::gui::framework::DialogWidget;
 public:
-	explicit RadioSenderServiceWidget(QWidget *parent = nullptr);
+	explicit RadioSenderServiceWidget(RadioSenderService *service, QWidget *parent = nullptr);
 	~RadioSenderServiceWidget() override;
 
 private:
 	bool acceptDialogDone(int result) override;
 	void saveConfig();
 	void updateReceivedLineLog();
+	void updateServiceControls();
 
 	Ui::RadioSenderServiceWidget *ui;
-	class RadioSenderService *m_service = nullptr;
+	RadioSenderService *m_service = nullptr;
 };
 
 } // namespace Event::services

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.h
@@ -22,6 +22,8 @@ private:
 	void updateReceivedLineLog();
 	void updateServiceControls();
 
+	void onTestPunch(const QString &line);
+
 	Ui::RadioSenderServiceWidget *ui;
 	RadioSenderService *m_service = nullptr;
 };

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.h
@@ -16,8 +16,8 @@ public:
 	explicit RadioSenderServiceWidget(RadioSenderService *service, QWidget *parent = nullptr);
 	~RadioSenderServiceWidget() override;
 
-private:
 	bool acceptDialogDone(int result) override;
+private:
 	void saveConfig();
 	void updateReceivedLineLog();
 	void updateServiceControls();

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.ui
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.ui
@@ -2,37 +2,208 @@
 <ui version="4.0">
  <class>Event::services::RadioSenderServiceWidget</class>
  <widget class="QWidget" name="Event::services::RadioSenderServiceWidget">
-  <property name="geometry"><rect><x>0</x><y>0</y><width>560</width><height>520</height></rect></property>
-  <property name="windowTitle"><string>Radio Sender</string></property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>560</width>
+    <height>520</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Radio Sender</string>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
-     <item row="0" column="0"><widget class="QLabel" name="lblListenAddress"><property name="text"><string>Listen address</string></property></widget></item>
-     <item row="0" column="1"><widget class="QLineEdit" name="edListenAddress"><property name="placeholderText"><string>0.0.0.0</string></property></widget></item>
-     <item row="1" column="0"><widget class="QLabel" name="lblPort"><property name="text"><string>Port</string></property></widget></item>
-     <item row="1" column="1"><widget class="QSpinBox" name="edPort"><property name="maximum"><number>65535</number></property><property name="value"><number>1122</number></property></widget></item>
-     <item row="2" column="0"><widget class="QLabel" name="lblStartControl"><property name="text"><string>Start control</string></property></widget></item>
-     <item row="2" column="1"><widget class="QSpinBox" name="edStartControl"><property name="maximum"><number>9999</number></property></widget></item>
-     <item row="3" column="0"><widget class="QLabel" name="lblFinishControl"><property name="text"><string>Finish control</string></property></widget></item>
-     <item row="3" column="1"><widget class="QSpinBox" name="edFinishControl"><property name="maximum"><number>9999</number></property><property name="value"><number>255</number></property></widget></item>
-     <item row="4" column="0"><widget class="QLabel" name="lblStartTolerance"><property name="text"><string>Start tolerance</string></property></widget></item>
-     <item row="4" column="1"><widget class="QSpinBox" name="edStartTolerance"><property name="suffix"><string> ms</string></property><property name="maximum"><number>10000</number></property><property name="value"><number>3000</number></property></widget></item>
-     <item row="5" column="0"><widget class="QLabel" name="lblFinishTolerance"><property name="text"><string>Finish tolerance</string></property></widget></item>
-     <item row="5" column="1"><widget class="QSpinBox" name="edFinishTolerance"><property name="suffix"><string> ms</string></property><property name="maximum"><number>10000</number></property><property name="value"><number>2000</number></property></widget></item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="lblListenAddress">
+       <property name="text">
+        <string>Listen address</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="edListenAddress">
+       <property name="placeholderText">
+        <string>0.0.0.0</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblPort">
+       <property name="text">
+        <string>Port</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="edPort">
+       <property name="maximum">
+        <number>65535</number>
+       </property>
+       <property name="value">
+        <number>1122</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="lblStartControl">
+       <property name="text">
+        <string>Start control</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QSpinBox" name="edStartControl">
+       <property name="maximum">
+        <number>9999</number>
+       </property>
+       <property name="value">
+        <number>11</number>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="lblFinishControl">
+       <property name="text">
+        <string>Finish control</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QSpinBox" name="edFinishControl">
+       <property name="maximum">
+        <number>9999</number>
+       </property>
+       <property name="value">
+        <number>901</number>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="lblStartTolerance">
+       <property name="text">
+        <string>Start tolerance</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QSpinBox" name="edStartTolerance">
+       <property name="suffix">
+        <string> ms</string>
+       </property>
+       <property name="maximum">
+        <number>10000</number>
+       </property>
+       <property name="value">
+        <number>3000</number>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="lblFinishTolerance">
+       <property name="text">
+        <string>Finish tolerance</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QSpinBox" name="edFinishTolerance">
+       <property name="suffix">
+        <string> ms</string>
+       </property>
+       <property name="maximum">
+        <number>10000</number>
+       </property>
+       <property name="value">
+        <number>2000</number>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="serviceButtonsLayout">
-     <item><spacer name="serviceButtonsSpacer"><property name="orientation"><enum>Qt::Horizontal</enum></property><property name="sizeHint" stdset="0"><size><width>40</width><height>20</height></size></property></spacer></item>
-     <item><widget class="QPushButton" name="btStart"><property name="text"><string>Start</string></property></widget></item>
-     <item><widget class="QPushButton" name="btStop"><property name="text"><string>Stop</string></property></widget></item>
+     <item>
+      <spacer name="serviceButtonsSpacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Service</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btStart">
+       <property name="text">
+        <string>Start</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btStop">
+       <property name="text">
+        <string>Stop</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="serviceButtonsLayout_2">
+     <item>
+      <widget class="QComboBox" name="edTestPunch">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="editable">
+        <bool>true</bool>
+       </property>
+       <property name="insertPolicy">
+        <enum>QComboBox::InsertPolicy::InsertAtTop</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btSendTestPunch">
+       <property name="text">
+        <string>Test</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
     <widget class="QGroupBox" name="grpReceivedLines">
-     <property name="title"><string>Last 20 received lines</string></property>
+     <property name="title">
+      <string>Last 20 received lines</string>
+     </property>
      <layout class="QVBoxLayout" name="receivedLinesLayout">
-      <item><widget class="QPlainTextEdit" name="edReceivedLines"><property name="readOnly"><bool>true</bool></property><property name="lineWrapMode"><enum>QPlainTextEdit::NoWrap</enum></property></widget></item>
+      <item>
+       <widget class="QPlainTextEdit" name="edReceivedLines">
+        <property name="lineWrapMode">
+         <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.ui
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.ui
@@ -22,6 +22,13 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="serviceButtonsLayout">
+     <item><spacer name="serviceButtonsSpacer"><property name="orientation"><enum>Qt::Horizontal</enum></property><property name="sizeHint" stdset="0"><size><width>40</width><height>20</height></size></property></spacer></item>
+     <item><widget class="QPushButton" name="btStart"><property name="text"><string>Start</string></property></widget></item>
+     <item><widget class="QPushButton" name="btStop"><property name="text"><string>Stop</string></property></widget></item>
+    </layout>
+   </item>
+   <item>
     <widget class="QGroupBox" name="grpReceivedLines">
      <property name="title"><string>Last 20 received lines</string></property>
      <layout class="QVBoxLayout" name="receivedLinesLayout">

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.ui
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.ui
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Event::services::RadioSenderServiceWidget</class>
+ <widget class="QWidget" name="Event::services::RadioSenderServiceWidget">
+  <property name="geometry"><rect><x>0</x><y>0</y><width>560</width><height>520</height></rect></property>
+  <property name="windowTitle"><string>Radio Sender</string></property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0"><widget class="QLabel" name="lblListenAddress"><property name="text"><string>Listen address</string></property></widget></item>
+     <item row="0" column="1"><widget class="QLineEdit" name="edListenAddress"><property name="placeholderText"><string>0.0.0.0</string></property></widget></item>
+     <item row="1" column="0"><widget class="QLabel" name="lblPort"><property name="text"><string>Port</string></property></widget></item>
+     <item row="1" column="1"><widget class="QSpinBox" name="edPort"><property name="maximum"><number>65535</number></property><property name="value"><number>1122</number></property></widget></item>
+     <item row="2" column="0"><widget class="QLabel" name="lblStartControl"><property name="text"><string>Start control</string></property></widget></item>
+     <item row="2" column="1"><widget class="QSpinBox" name="edStartControl"><property name="maximum"><number>9999</number></property></widget></item>
+     <item row="3" column="0"><widget class="QLabel" name="lblFinishControl"><property name="text"><string>Finish control</string></property></widget></item>
+     <item row="3" column="1"><widget class="QSpinBox" name="edFinishControl"><property name="maximum"><number>9999</number></property><property name="value"><number>255</number></property></widget></item>
+     <item row="4" column="0"><widget class="QLabel" name="lblStartTolerance"><property name="text"><string>Start tolerance</string></property></widget></item>
+     <item row="4" column="1"><widget class="QSpinBox" name="edStartTolerance"><property name="suffix"><string> ms</string></property><property name="maximum"><number>10000</number></property><property name="value"><number>3000</number></property></widget></item>
+     <item row="5" column="0"><widget class="QLabel" name="lblFinishTolerance"><property name="text"><string>Finish tolerance</string></property></widget></item>
+     <item row="5" column="1"><widget class="QSpinBox" name="edFinishTolerance"><property name="suffix"><string> ms</string></property><property name="maximum"><number>10000</number></property><property name="value"><number>2000</number></property></widget></item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="grpReceivedLines">
+     <property name="title"><string>Last 20 received lines</string></property>
+     <layout class="QVBoxLayout" name="receivedLinesLayout">
+      <item><widget class="QPlainTextEdit" name="edReceivedLines"><property name="readOnly"><bool>true</bool></property><property name="lineWrapMode"><enum>QPlainTextEdit::NoWrap</enum></property></widget></item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.ui
+++ b/quickevent/app/quickevent/plugins/Event/src/services/radiosender/radiosenderservicewidget.ui
@@ -162,6 +162,27 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="serviceButtonsLayout_4">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Format</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEdit">
+       <property name="text">
+        <string>{Control};{Bib};{Time:HH:mm:ss.fff};{Status};{Cancellation};{CRLF}</string>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="serviceButtonsLayout_2">
      <item>
       <widget class="QComboBox" name="edTestPunch">

--- a/quickevent/app/quickevent/plugins/Oris/src/txtimporter.cpp
+++ b/quickevent/app/quickevent/plugins/Oris/src/txtimporter.cpp
@@ -290,7 +290,7 @@ void TxtImporter::importRunsCzeCSV()
 	}
 
 	int stage_id = getPlugin<EventPlugin>()->currentStageId();
-	auto start00_day_msec = getPlugin<EventPlugin>()->stageStartTime(stage_id).msecsSinceStartOfDay();
+	auto start00_day_msec = getPlugin<EventPlugin>()->stageStartMsec(stage_id);
 
 	try {
 		QFile f(fn);
@@ -404,7 +404,7 @@ void TxtImporter::importRunsIdCSV()
 	}
 
 	int stage_id = getPlugin<EventPlugin>()->currentStageId();
-	auto start00_day_msec = getPlugin<EventPlugin>()->stageStartTime(stage_id).msecsSinceStartOfDay();
+	auto start00_day_msec = getPlugin<EventPlugin>()->stageStartMsec(stage_id);
 
 	try {
 		QFile f(fn);
@@ -518,7 +518,7 @@ void TxtImporter::importRunsIofCSV()
 	}
 
 	int stage_id = getPlugin<EventPlugin>()->currentStageId();
-	auto start00_day_msec = getPlugin<EventPlugin>()->stageStartTime(stage_id).msecsSinceStartOfDay();
+	auto start00_day_msec = getPlugin<EventPlugin>()->stageStartMsec(stage_id);
 
 	try {
 		QFile f(fn);

--- a/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
@@ -68,7 +68,9 @@ int RelaysPlugin::editRelay(int id, int mode)
 
 void RelaysPlugin::onInstalled()
 {
-	m_partWidget = qff::initPluginWidget<RelaysWidget, PartWidget>(tr("&Relays"), featureId());
+	auto [part_widget, relays_widget] = qff::initPluginWidget<RelaysWidget, PartWidget>(tr("&Relays"), featureId());
+	m_partWidget = part_widget;
+	Q_UNUSED(relays_widget)
 
 	auto *scw = qobject_cast<qff::StackedCentralWidget*>(qff::MainWindow::frameWork()->centralWidget());
 	if(scw)

--- a/quickevent/app/quickevent/plugins/Runs/src/cardflagsdialog.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/cardflagsdialog.cpp
@@ -1,7 +1,7 @@
 #include "cardflagsdialog.h"
 #include "ui_cardflagsdialog.h"
 
-#include "runstablemodel.h"
+#include <quickevent/gui/og/sqltablemodel.h>
 
 namespace Runs {
 

--- a/quickevent/app/quickevent/plugins/Runs/src/runflagsdialog.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runflagsdialog.cpp
@@ -1,7 +1,7 @@
 #include "runflagsdialog.h"
 #include "ui_runflagsdialog.h"
 
-#include "runstablemodel.h"
+#include <quickevent/gui/og/sqltablemodel.h>
 
 namespace Runs {
 

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -21,6 +21,7 @@
 #include <quickevent/core/si/punchrecord.h>
 #include <quickevent/core/runstatus.h>
 
+#include <qf/gui/framework/application.h>
 #include <qf/gui/framework/mainwindow.h>
 #include <qf/gui/framework/dockwidget.h>
 #include <qf/gui/action.h>
@@ -1356,6 +1357,66 @@ QVariantMap RunsPlugin::runsRecord(int run_id)
 	}
 	return {};
 }
+
+// timeMs = effective_finish - effective_start + penaltyTimeMs
+// effective_start  = startGateTime (as ms from stage start) if within tolerance, else startTimeMs
+// effective_finish = finishGateTime (as ms from stage start) if within tolerance, else finishTimeMs
+void RunsPlugin::computeStageTime(int run_id)
+{
+	static constexpr auto FLD_STAGE_ID = "stageid";
+	static constexpr auto FLD_START_TIME_MS = "starttimems";
+	static constexpr auto FLD_FINISH_TIME_MS = "finishtimems";
+	static constexpr auto FLD_START_GATE_TIME = "startgatetime";
+	static constexpr auto FLD_FINISH_GATE_TIME = "finishgatetime";
+	static constexpr auto FLD_PENALTY_TIME_MS = "penaltytimems";
+	static constexpr auto FLD_TIME_MS = "timems";
+
+	const auto run = qff::Application::instance()->readDbRecord("runs", run_id,
+		QStringList{
+			FLD_STAGE_ID,
+			FLD_START_TIME_MS,
+			FLD_FINISH_TIME_MS,
+			FLD_START_GATE_TIME,
+			FLD_FINISH_GATE_TIME,
+			FLD_PENALTY_TIME_MS,
+			FLD_TIME_MS
+		});
+	if(!run) {
+		qfWarning() << Q_FUNC_INFO << "run not found, run_id:" << run_id;
+		return;
+	}
+	const QVariant start_ms_v = run->value(FLD_START_TIME_MS);
+	const QVariant finish_ms_v = run->value(FLD_FINISH_TIME_MS);
+	const QVariant orig_time_ms_v = run->value(FLD_TIME_MS);
+	QVariant time_ms_v;
+	if(start_ms_v.isValid() && finish_ms_v.isValid()) {
+		const int stage_id = run->value(FLD_STAGE_ID).toInt();
+		auto *event_plugin = getPlugin<EventPlugin>();
+		const QDateTime stage_start_dt = event_plugin->stageStartDateTime(stage_id);
+		const auto &config = event_plugin->appDbConfig().radioSenderConfig();
+		const qint64 start_ms = start_ms_v.toLongLong();
+		const qint64 finish_ms = finish_ms_v.toLongLong();
+
+		const auto start_gate_dt = run->value(FLD_START_GATE_TIME).toDateTime();
+		const qint64 start_gate_ms = stage_start_dt.msecsTo(start_gate_dt);
+		const bool use_start_gate = start_gate_dt.isValid()
+			&& std::abs(start_gate_ms - start_ms) <= config.startToleranceMs;
+
+		const auto finish_gate_dt = run->value(FLD_FINISH_GATE_TIME).toDateTime();
+		const qint64 finish_gate_ms = stage_start_dt.msecsTo(finish_gate_dt);
+		const bool use_finish_gate = finish_gate_dt.isValid()
+			&& std::abs(finish_gate_ms - finish_ms) <= config.finishToleranceMs;
+
+		const int penalty_ms = run->value(FLD_PENALTY_TIME_MS).toInt();
+		const qint64 time_ms = (use_finish_gate ? finish_gate_ms : finish_ms)
+			- (use_start_gate ? start_gate_ms : start_ms)
+			+ penalty_ms;
+		time_ms_v = time_ms;
+	}
+	qff::Application::instance()->updateDbRecord(
+		QStringLiteral("runs"), run_id, {{FLD_TIME_MS, time_ms_v}}, this);
+}
+
 
 void RunsPlugin::setRunsRecord(int run_id, const QVariant &rec)
 {

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -2,6 +2,7 @@
 
 #include "nstagesreportoptionsdialog.h"
 #include "runstablemodel.h"
+#include "runssettingspage.h"
 #include "runswidget.h"
 #include "runstabledialogwidget.h"
 #include "eventstatisticswidget.h"
@@ -10,6 +11,8 @@
 #include "partwidget.h"
 // #include "../../Competitors/src/competitorwidget.h"
 #include "../../CardReader/src/cardreaderplugin.h"
+#include "../../Core/src/coreplugin.h"
+#include "../../Core/src/widgets/settingsdialog.h"
 #include "../../Event/src/eventplugin.h"
 #include "../../Event/src/services/qx/qxlateregistrationswidget.h"
 
@@ -115,6 +118,7 @@ void RunsPlugin::onInstalled()
 	qfLogFuncFrame();
 	qff::MainWindow *fwk = qff::MainWindow::frameWork();
 	m_partWidget = qff::initPluginWidget<RunsWidget, PartWidget>(tr("&Runs"), featureId());
+	getPlugin<Core::CorePlugin>()->settingsDialog()->addPage(new RunsSettingsPage());
 
 	//connect(getPlugin<CompetitorsPlugin>(), &CompetitorsPlugin::competitorEdited, this, &RunsPlugin::clearRunnersTableCache);
 	connect(getPlugin<EventPlugin>(), &Event::EventPlugin::dbEventNotify, this, [this](const QString &domain, const QVariant &payload) {

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -3043,6 +3043,7 @@ bool RunsPlugin::exportStartListCurrentStageTvGraphics(const QString &file_name)
 }
 namespace {
     constexpr auto HIDDEN_COLUMNS_CONFIG_KEY = "runs.hiddenColumns";
+    constexpr auto COLUMN_ORDER_CONFIG_KEY = "runs.columnOrder";
 }
 QStringList RunsPlugin::loadRunsTableHiddenColumns()
 {
@@ -3072,6 +3073,33 @@ void RunsPlugin::saveRunsTableHiddenColumns(const QStringList &hidden_columns)
 
 	if(exec_query("UPDATE config SET cvalue=:value, ctype='QString' WHERE ckey=:key", HIDDEN_COLUMNS_CONFIG_KEY, hidden_columns_value) < 1) {
 		exec_query("INSERT INTO config (ckey, cvalue, ctype) VALUES (:key, :value, 'QString')", HIDDEN_COLUMNS_CONFIG_KEY, hidden_columns_value);
+	}
+}
+QStringList RunsPlugin::loadRunsTableColumnOrder()
+{
+	qf::core::sql::Query q;
+	q.prepare(QStringLiteral("SELECT cvalue FROM config WHERE ckey=:key"), qf::core::Exception::Throw);
+	q.bindValue(QStringLiteral(":key"), QLatin1String(COLUMN_ORDER_CONFIG_KEY));
+	q.exec(qf::core::Exception::Throw);
+	if(q.next()) {
+		return q.value("cvalue").toString().split(',', Qt::SkipEmptyParts);
+	}
+	return QStringList();
+}
+void RunsPlugin::saveRunsTableColumnOrder(const QStringList &ordered_columns)
+{
+	using namespace qf::core::sql;
+	const auto value = ordered_columns.join(',');
+	auto exec_query = [](const QString &sql, const QString &key, const QString &val) {
+		Query query(Connection::forName());
+		query.prepare(sql, qf::core::Exception::Throw);
+		query.bindValue(":key", key);
+		query.bindValue(":value", val);
+		query.exec(qf::core::Exception::Throw);
+		return query.numRowsAffected();
+	};
+	if(exec_query("UPDATE config SET cvalue=:value, ctype='QString' WHERE ckey=:key", COLUMN_ORDER_CONFIG_KEY, value) < 1) {
+		exec_query("INSERT INTO config (ckey, cvalue, ctype) VALUES (:key, :value, 'QString')", COLUMN_ORDER_CONFIG_KEY, value);
 	}
 }
 }

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -117,7 +117,9 @@ void RunsPlugin::onInstalled()
 {
 	qfLogFuncFrame();
 	qff::MainWindow *fwk = qff::MainWindow::frameWork();
-	m_partWidget = qff::initPluginWidget<RunsWidget, PartWidget>(tr("&Runs"), featureId());
+	auto [part_widget, runs_widget] = qff::initPluginWidget<RunsWidget, PartWidget>(tr("&Runs"), featureId());
+	m_partWidget = part_widget;
+	m_runsWidget = runs_widget;
 	getPlugin<Core::CorePlugin>()->settingsDialog()->addPage(new RunsSettingsPage());
 
 	//connect(getPlugin<CompetitorsPlugin>(), &CompetitorsPlugin::competitorEdited, this, &RunsPlugin::clearRunnersTableCache);
@@ -3039,6 +3041,37 @@ bool RunsPlugin::exportStartListCurrentStageTvGraphics(const QString &file_name)
 	qfInfo() << "exported:" << file_name;
 	return true;
 }
+namespace {
+    constexpr auto HIDDEN_COLUMNS_CONFIG_KEY = "runs.hiddenColumns";
+}
+QStringList RunsPlugin::loadRunsTableHiddenColumns()
+{
+    qf::core::sql::Query q;
+	q.prepare(QStringLiteral("SELECT cvalue FROM config WHERE ckey=:key"), qf::core::Exception::Throw);
+	q.bindValue(QStringLiteral(":key"), QLatin1String(HIDDEN_COLUMNS_CONFIG_KEY));
+	q.exec(qf::core::Exception::Throw);
+	if(q.next()) {
+		const auto hidden_columns = q.value("cvalue").toString().split(',', Qt::SkipEmptyParts);
+		return hidden_columns;
+	}
+	return QStringList();
+}
+void RunsPlugin::saveRunsTableHiddenColumns(const QStringList &hidden_columns)
+{
+    using namespace qf::core::sql;
+	const auto hidden_columns_value = hidden_columns.join(',');
 
+	auto exec_query = [](const QString &sql, const QString &key, const QString &value) {
+		Query query(Connection::forName());
+		query.prepare(sql, qf::core::Exception::Throw);
+		query.bindValue(":key", key);
+		query.bindValue(":value", value);
+		query.exec(qf::core::Exception::Throw);
+		return query.numRowsAffected();
+	};
 
+	if(exec_query("UPDATE config SET cvalue=:value, ctype='QString' WHERE ckey=:key", HIDDEN_COLUMNS_CONFIG_KEY, hidden_columns_value) < 1) {
+		exec_query("INSERT INTO config (ckey, cvalue, ctype) VALUES (:key, :value, 'QString')", HIDDEN_COLUMNS_CONFIG_KEY, hidden_columns_value);
+	}
+}
 }

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.h
@@ -12,13 +12,12 @@
 #include <qf/core/utils/treetable.h>
 
 namespace qf {
-	namespace core {
-		namespace utils {
-			class Table;
-			class TreeTable;
-			class TreeTableRow;
-		}
+	namespace core::utils {
+		class Table;
+		class TreeTable;
+		class TreeTableRow;
 	}
+
 	namespace gui {
 		class Action;
 		namespace framework {
@@ -29,6 +28,8 @@ namespace qf {
 }
 
 namespace qf::core::sql { class QueryBuilder; }
+
+class RunsWidget;
 
 namespace Runs {
 
@@ -47,7 +48,7 @@ public:
 
 	QF_PROPERTY_IMPL2(int, s, S, electedStageId, 1)
 
-	//qf::gui::framework::PartWidget *partWidget() {return m_partWidget;}
+	RunsWidget *runsWidget() {return m_runsWidget;}
 
 	const qf::core::utils::Table& runnersTable(int stage_id);
 	Q_SLOT void clearRunnersTableCache();
@@ -128,6 +129,9 @@ public:
 	QString resultsIofXml30Stage(int stage_id);
 	int competitorForRun(int run_id);
 	int runForCompetitorStage(int competitor_id, int stage_id);
+
+	static QStringList loadRunsTableHiddenColumns();
+	static void saveRunsTableHiddenColumns(const QStringList &hidden_columns);
 private:
 	Q_SLOT void onInstalled();
 
@@ -144,6 +148,7 @@ private:
 	void addStartTimeTextToClass(qf::core::utils::TreeTable &tt2, const int stages_count, const QVector<qint64> &start00_epoch_sec, const quickevent::gui::ReportOptionsDialog::StartTimeFormat start_time_format);
 private:
 	qf::gui::framework::PartWidget *m_partWidget = nullptr;
+	RunsWidget *m_runsWidget = nullptr;
 	qf::core::utils::Table m_runnersTableCache;
 	int m_runnersTableCacheStageId = 0;
 	qf::gui::framework::DockWidget *m_eventStatisticsDockWidget = nullptr;

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.h
@@ -132,6 +132,8 @@ public:
 
 	static QStringList loadRunsTableHiddenColumns();
 	static void saveRunsTableHiddenColumns(const QStringList &hidden_columns);
+	static QStringList loadRunsTableColumnOrder();
+	static void saveRunsTableColumnOrder(const QStringList &ordered_columns);
 private:
 	Q_SLOT void onInstalled();
 

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.h
@@ -77,7 +77,7 @@ public:
 
 	Q_INVOKABLE QVariantMap printAwardsOptionsWithDialog(const QVariantMap &opts);
 
-        bool exportStartListStageIofXml30(int stage_id, const QString &file_name, quickevent::gui::ReportOptionsDialog::VacantsOption vacants_option);
+    bool exportStartListStageIofXml30(int stage_id, const QString &file_name, quickevent::gui::ReportOptionsDialog::VacantsOption vacants_option);
 	bool exportStartListCurrentStageCsvSime(const QString &file_name, bool bibs, QString sql_where);
 	bool exportStartListCurrentStageTvGraphics(const QString &file_name);
 
@@ -124,7 +124,7 @@ public:
 	QString export_resultsHtmlStage(bool with_laps = false);
 	void export_resultsHtmlStageWithLaps();
 	void export_resultsHtmlNStages();
-        QString startListStageIofXml30(int stage_id, quickevent::gui::ReportOptionsDialog::VacantsOption vacants_option);
+    QString startListStageIofXml30(int stage_id, quickevent::gui::ReportOptionsDialog::VacantsOption vacants_option);
 	QString resultsIofXml30Stage(int stage_id);
 	int competitorForRun(int run_id);
 	int runForCompetitorStage(int competitor_id, int stage_id);
@@ -153,4 +153,3 @@ private:
 }
 
 #endif // RUNS_RUNSPLUGIN_H
-

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.h
@@ -92,6 +92,8 @@ public:
 
 	qf::core::sql::QueryBuilder runsQuery(int stage_id, int class_id = 0, bool show_offrace = false);
 	QVariantMap runsRecord(int run_id);
+
+	void computeStageTime(int run_id);
 	void setRunsRecord(int run_id, const QVariant &rec);
 
 	qf::core::sql::QueryBuilder startListQuery();

--- a/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.cpp
@@ -3,6 +3,8 @@
 
 #include "runstablemodel.h"
 #include "runstablewidget.h"
+#include "runsplugin.h"
+#include "runswidget.h"
 
 #include <plugins/Event/src/eventplugin.h>
 
@@ -15,13 +17,15 @@
 #include <QCheckBox>
 
 namespace Runs {
-namespace {
 
-const auto config_key = QStringLiteral("runs.hiddenColumns");
+namespace {
 
 RunsTableWidget *runsTableWidget()
 {
-	return qf::gui::framework::MainWindow::frameWork()->findChild<RunsTableWidget*>();
+    auto runs_plugin = qf::gui::framework::getPlugin<RunsPlugin>();
+	auto *runs_widget = runs_plugin->runsWidget();
+	Q_ASSERT(runs_widget);
+	return runs_widget->findChild<RunsTableWidget*>();
 }
 
 }
@@ -33,7 +37,7 @@ RunsSettingsPage::RunsSettingsPage(QWidget *parent)
 	ui = new ::Ui::RunsSettingsPage;
 	ui->setupUi(this);
 
-	auto *model = new RunsTableModel(this);
+	auto *model = runsTableWidget()->runsModel();
 	for(int column = 0; column < model->columnCount({}); ++column) {
 		auto *check_box = new QCheckBox(model->headerData(column, Qt::Horizontal).toString(), this);
 		ui->columnsLayout->addWidget(check_box);
@@ -72,34 +76,17 @@ void RunsSettingsPage::save()
 		return;
 	}
 
-	RunsTableModel model;
 	QStringList hidden_columns;
 	auto *runs_table = runsTableWidget();
 	for(auto it = m_columnCheckBoxes.cbegin(); it != m_columnCheckBoxes.cend(); ++it) {
 		if(!it.value()->isChecked()) {
-			hidden_columns << model.columnDefinition(it.key()).fieldName();
+			hidden_columns << runs_table->runsModel()->columnDefinition(it.key()).fieldName();
 		}
 		if(runs_table) {
 			runs_table->setColumnVisible(it.key(), it.value()->isChecked());
 		}
 	}
-
-	using namespace qf::core::sql;
-	Query update_query(Connection::forName());
-	update_query.prepare("UPDATE config SET cvalue=:value, ctype='QString' WHERE ckey=:key", qf::core::Exception::Throw);
-	update_query.bindValue(":key", config_key);
-	update_query.bindValue(":value", hidden_columns.join(','));
-	update_query.exec(qf::core::Exception::Throw);
-	if(update_query.numRowsAffected() < 1) {
-		Query insert_query(Connection::forName());
-		insert_query.prepare("INSERT INTO config (ckey, cvalue, ctype) VALUES (:key, :value, 'QString')", qf::core::Exception::Throw);
-		insert_query.bindValue(":key", config_key);
-		insert_query.bindValue(":value", hidden_columns.join(','));
-		insert_query.exec(qf::core::Exception::Throw);
-	}
-
-	Query delete_legacy_query(Connection::forName());
-	delete_legacy_query.exec("DELETE FROM config WHERE ckey LIKE 'runs.tableColumn.%' OR ckey='runs.visibleColumns'", qf::core::Exception::Throw);
+	RunsPlugin::saveRunsTableHiddenColumns(hidden_columns);
 }
 
 } // namespace Runs

--- a/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.cpp
@@ -1,0 +1,105 @@
+#include "runssettingspage.h"
+#include "ui_runssettingspage.h"
+
+#include "runstablemodel.h"
+#include "runstablewidget.h"
+
+#include <plugins/Event/src/eventplugin.h>
+
+#include <qf/core/sql/connection.h>
+#include <qf/core/sql/query.h>
+#include <qf/gui/framework/mainwindow.h>
+#include <qf/gui/framework/plugin.h>
+#include <qf/gui/tableview.h>
+
+#include <QCheckBox>
+
+namespace Runs {
+namespace {
+
+const auto config_key = QStringLiteral("runs.hiddenColumns");
+
+RunsTableWidget *runsTableWidget()
+{
+	return qf::gui::framework::MainWindow::frameWork()->findChild<RunsTableWidget*>();
+}
+
+}
+
+RunsSettingsPage::RunsSettingsPage(QWidget *parent)
+	: Super(parent)
+{
+	m_caption = tr("Runs");
+	ui = new ::Ui::RunsSettingsPage;
+	ui->setupUi(this);
+
+	auto *model = new RunsTableModel(this);
+	for(int column = 0; column < model->columnCount({}); ++column) {
+		auto *check_box = new QCheckBox(model->headerData(column, Qt::Horizontal).toString(), this);
+		ui->columnsLayout->addWidget(check_box);
+		m_columnCheckBoxes.insert(column, check_box);
+	}
+	ui->columnsLayout->addStretch();
+}
+
+RunsSettingsPage::~RunsSettingsPage()
+{
+	delete ui;
+}
+
+void RunsSettingsPage::load()
+{
+	for(auto *check_box : m_columnCheckBoxes) {
+		check_box->setChecked(true);
+	}
+
+	if(!qf::gui::framework::getPlugin<Event::EventPlugin>()->isEventOpen()) {
+		setEnabled(false);
+		return;
+	}
+	setEnabled(true);
+
+	if(auto *runs_table = runsTableWidget()) {
+		for(auto it = m_columnCheckBoxes.cbegin(); it != m_columnCheckBoxes.cend(); ++it) {
+			it.value()->setChecked(!runs_table->tableView()->isColumnHidden(it.key()));
+		}
+	}
+}
+
+void RunsSettingsPage::save()
+{
+	if(!qf::gui::framework::getPlugin<Event::EventPlugin>()->isEventOpen()) {
+		return;
+	}
+
+	RunsTableModel model;
+	QStringList hidden_columns;
+	auto *runs_table = runsTableWidget();
+	for(auto it = m_columnCheckBoxes.cbegin(); it != m_columnCheckBoxes.cend(); ++it) {
+		if(!it.value()->isChecked()) {
+			hidden_columns << model.columnDefinition(it.key()).fieldName();
+		}
+		if(runs_table) {
+			runs_table->setColumnVisible(it.key(), it.value()->isChecked());
+		}
+	}
+
+	using namespace qf::core::sql;
+	Query update_query(Connection::forName());
+	update_query.prepare("UPDATE config SET cvalue=:value, ctype='QString' WHERE ckey=:key", qf::core::Exception::Throw);
+	update_query.bindValue(":key", config_key);
+	update_query.bindValue(":value", hidden_columns.join(','));
+	update_query.exec(qf::core::Exception::Throw);
+	if(update_query.numRowsAffected() < 1) {
+		Query insert_query(Connection::forName());
+		insert_query.prepare("INSERT INTO config (ckey, cvalue, ctype) VALUES (:key, :value, 'QString')", qf::core::Exception::Throw);
+		insert_query.bindValue(":key", config_key);
+		insert_query.bindValue(":value", hidden_columns.join(','));
+		insert_query.exec(qf::core::Exception::Throw);
+	}
+
+	Query delete_legacy_query(Connection::forName());
+	delete_legacy_query.exec("DELETE FROM config WHERE ckey LIKE 'runs.tableColumn.%' OR ckey='runs.visibleColumns'", qf::core::Exception::Throw);
+}
+
+} // namespace Runs

--- a/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.cpp
@@ -8,13 +8,12 @@
 
 #include <plugins/Event/src/eventplugin.h>
 
-#include <qf/core/sql/connection.h>
-#include <qf/core/sql/query.h>
 #include <qf/gui/framework/mainwindow.h>
 #include <qf/gui/framework/plugin.h>
 #include <qf/gui/tableview.h>
 
-#include <QCheckBox>
+#include <QHeaderView>
+#include <QListWidget>
 
 namespace Runs {
 
@@ -39,11 +38,12 @@ RunsSettingsPage::RunsSettingsPage(QWidget *parent)
 
 	auto *model = runsTableWidget()->runsModel();
 	for(int column = 0; column < model->columnCount({}); ++column) {
-		auto *check_box = new QCheckBox(model->headerData(column, Qt::Horizontal).toString(), this);
-		ui->columnsLayout->addWidget(check_box);
-		m_columnCheckBoxes.insert(column, check_box);
+		auto *item = new QListWidgetItem(model->headerData(column, Qt::Horizontal).toString());
+		item->setData(Qt::UserRole, column);
+		item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsDragEnabled);
+		item->setCheckState(Qt::Checked);
+		ui->lwColumns->addItem(item);
 	}
-	ui->columnsLayout->addStretch();
 }
 
 RunsSettingsPage::~RunsSettingsPage()
@@ -53,8 +53,9 @@ RunsSettingsPage::~RunsSettingsPage()
 
 void RunsSettingsPage::load()
 {
-	for(auto *check_box : m_columnCheckBoxes) {
-		check_box->setChecked(true);
+	// Default: all visible
+	for(int i = 0; i < ui->lwColumns->count(); ++i) {
+		ui->lwColumns->item(i)->setCheckState(Qt::Checked);
 	}
 
 	if(!qf::gui::framework::getPlugin<Event::EventPlugin>()->isEventOpen()) {
@@ -63,10 +64,33 @@ void RunsSettingsPage::load()
 	}
 	setEnabled(true);
 
-	if(auto *runs_table = runsTableWidget()) {
-		for(auto it = m_columnCheckBoxes.cbegin(); it != m_columnCheckBoxes.cend(); ++it) {
-			it.value()->setChecked(!runs_table->tableView()->isColumnHidden(it.key()));
+	auto *runs_table = runsTableWidget();
+	if(!runs_table)
+		return;
+
+	auto *hh = runs_table->tableView()->horizontalHeader();
+	const int count = ui->lwColumns->count();
+
+	// Reorder list items to match the current visual column order in the header view
+	for(int target_visual = 0; target_visual < count; ++target_visual) {
+		const int logical = hh->logicalIndex(target_visual);
+		// Find the item that owns this logical index (search from target_visual onward)
+		for(int i = target_visual; i < count; ++i) {
+			if(ui->lwColumns->item(i)->data(Qt::UserRole).toInt() == logical) {
+				if(i != target_visual) {
+					auto *item = ui->lwColumns->takeItem(i);
+					ui->lwColumns->insertItem(target_visual, item);
+				}
+				break;
+			}
 		}
+	}
+
+	// Set check state based on current header visibility
+	for(int i = 0; i < count; ++i) {
+		auto *item = ui->lwColumns->item(i);
+		const int logical = item->data(Qt::UserRole).toInt();
+		item->setCheckState(hh->isSectionHidden(logical) ? Qt::Unchecked : Qt::Checked);
 	}
 }
 
@@ -76,17 +100,30 @@ void RunsSettingsPage::save()
 		return;
 	}
 
-	QStringList hidden_columns;
 	auto *runs_table = runsTableWidget();
-	for(auto it = m_columnCheckBoxes.cbegin(); it != m_columnCheckBoxes.cend(); ++it) {
-		if(!it.value()->isChecked()) {
-			hidden_columns << runs_table->runsModel()->columnDefinition(it.key()).fieldName();
-		}
-		if(runs_table) {
-			runs_table->setColumnVisible(it.key(), it.value()->isChecked());
+	if(!runs_table)
+		return;
+
+	const int count = ui->lwColumns->count();
+
+	QStringList hidden_columns;
+	QStringList column_order;
+
+	for(int i = 0; i < count; ++i) {
+		const auto *item = ui->lwColumns->item(i);
+		const int logical = item->data(Qt::UserRole).toInt();
+		const auto field_name = runs_table->runsModel()->columnDefinition(logical).fieldName();
+		column_order << field_name;
+		if(item->checkState() != Qt::Checked) {
+			hidden_columns << field_name;
 		}
 	}
+
+	runs_table->setColumnsOrder(column_order);
+	runs_table->setColumnsHidden(hidden_columns);
+
 	RunsPlugin::saveRunsTableHiddenColumns(hidden_columns);
+	RunsPlugin::saveRunsTableColumnOrder(column_order);
 }
 
 } // namespace Runs

--- a/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.cpp
@@ -21,7 +21,7 @@ namespace {
 
 RunsTableWidget *runsTableWidget()
 {
-    auto runs_plugin = qf::gui::framework::getPlugin<RunsPlugin>();
+	auto runs_plugin = qf::gui::framework::getPlugin<RunsPlugin>();
 	auto *runs_widget = runs_plugin->runsWidget();
 	Q_ASSERT(runs_widget);
 	return runs_widget->findChild<RunsTableWidget*>();
@@ -38,7 +38,8 @@ RunsSettingsPage::RunsSettingsPage(QWidget *parent)
 
 	auto *model = runsTableWidget()->runsModel();
 	for(int column = 0; column < model->columnCount({}); ++column) {
-		auto *item = new QListWidgetItem(model->headerData(column, Qt::Horizontal).toString());
+		QString col_name = model->headerData(column, Qt::Horizontal).toString();
+		auto *item = new QListWidgetItem(col_name);
 		item->setData(Qt::UserRole, column);
 		item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsDragEnabled);
 		item->setCheckState(Qt::Checked);
@@ -119,8 +120,8 @@ void RunsSettingsPage::save()
 		}
 	}
 
-	runs_table->setColumnsOrder(column_order);
 	runs_table->setColumnsHidden(hidden_columns);
+	runs_table->setColumnsOrder(column_order);
 
 	RunsPlugin::saveRunsTableHiddenColumns(hidden_columns);
 	RunsPlugin::saveRunsTableColumnOrder(column_order);

--- a/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.h
@@ -2,10 +2,6 @@
 
 #include <plugins/Core/src/widgets/settingspage.h>
 
-#include <QMap>
-
-class QCheckBox;
-
 namespace Ui {
 class RunsSettingsPage;
 }
@@ -27,7 +23,6 @@ public:
 
 private:
 	::Ui::RunsSettingsPage *ui;
-	QMap<int, QCheckBox*> m_columnCheckBoxes;
 };
 
 } // namespace Runs

--- a/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <plugins/Core/src/widgets/settingspage.h>
+
+#include <QMap>
+
+class QCheckBox;
+
+namespace Ui {
+class RunsSettingsPage;
+}
+
+namespace Runs {
+
+class RunsSettingsPage : public Core::SettingsPage
+{
+	Q_OBJECT
+private:
+	using Super = Core::SettingsPage;
+
+public:
+	explicit RunsSettingsPage(QWidget *parent = nullptr);
+	~RunsSettingsPage() override;
+
+	void load() override;
+	void save() override;
+
+private:
+	::Ui::RunsSettingsPage *ui;
+	QMap<int, QCheckBox*> m_columnCheckBoxes;
+};
+
+} // namespace Runs

--- a/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.ui
+++ b/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.ui
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>RunsSettingsPage</class>
+ <widget class="QWidget" name="RunsSettingsPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Visible columns</string>
+     </property>
+     <layout class="QVBoxLayout" name="columnsLayout"/>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.ui
+++ b/quickevent/app/quickevent/plugins/Runs/src/runssettingspage.ui
@@ -17,9 +17,32 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Visible columns</string>
+      <string>Column visibility and order (Drag to reorder)</string>
      </property>
-     <layout class="QVBoxLayout" name="columnsLayout"/>
+     <layout class="QVBoxLayout" name="columnsLayout">
+      <property name="leftMargin">
+       <number>3</number>
+      </property>
+      <property name="topMargin">
+       <number>3</number>
+      </property>
+      <property name="rightMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <item>
+       <widget class="QListWidget" name="lwColumns">
+        <property name="dragDropMode">
+         <enum>QAbstractItemView::DragDropMode::InternalMove</enum>
+        </property>
+        <property name="defaultDropAction">
+         <enum>Qt::DropAction::MoveAction</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/quickevent/app/quickevent/plugins/Runs/src/runstableitemdelegate.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstableitemdelegate.cpp
@@ -1,6 +1,7 @@
 #include "runstableitemdelegate.h"
 #include "runstablemodel.h"
 
+#include <qassert.h>
 #include <quickevent/core/og/timems.h>
 
 #include <qf/gui/tableview.h>
@@ -14,6 +15,7 @@
 #include <plugins/Event/src/eventplugin.h>
 
 #include <QPainter>
+#include <QLineEdit>
 
 using qf::gui::framework::getPlugin;
 using Event::EventPlugin;
@@ -21,6 +23,63 @@ using Event::EventPlugin;
 RunsTableItemDelegate::RunsTableItemDelegate(qf::gui::TableView * parent)
 	: Super(parent)
 {
+}
+
+QWidget *RunsTableItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+	if(index.column() == RunsTableModel::col_runs_startGateTime || index.column() == RunsTableModel::col_runs_finishGateTime) {
+		return new QLineEdit(parent);
+	}
+	return Super::createEditor(parent, option, index);
+}
+
+void RunsTableItemDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
+{
+	if(index.column() == RunsTableModel::col_runs_startGateTime
+	|| index.column() == RunsTableModel::col_runs_corridorTime
+	|| index.column() == RunsTableModel::col_runs_finishGateTime) {
+		auto *le = qobject_cast<QLineEdit*>(editor);
+		if(le) {
+			QDateTime dt = index.data(Qt::EditRole).toDateTime();
+			if(dt.isValid()) {
+				auto *runs_model = qobject_cast<RunsTableModel*>(view()->tableModel());
+				Q_ASSERT(runs_model);
+				QDateTime stage_start = getPlugin<EventPlugin>()->stageStartDateTime(runs_model->stageId());
+				int msec = static_cast<int>(stage_start.msecsTo(dt));
+				le->setText(quickevent::core::og::TimeMs(msec).toString());
+			} else {
+				le->clear();
+			}
+		}
+		return;
+	}
+	Super::setEditorData(editor, index);
+}
+
+void RunsTableItemDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
+{
+	if(index.column() == RunsTableModel::col_runs_startGateTime
+	|| index.column() == RunsTableModel::col_runs_corridorTime
+	|| index.column() == RunsTableModel::col_runs_finishGateTime) {
+		auto *le = qobject_cast<QLineEdit*>(editor);
+		if(le) {
+			const QString text = le->text().trimmed();
+			if(text.isEmpty()) {
+				model->setData(index, QVariant());
+			} else {
+				auto ms = quickevent::core::og::TimeMs::fromString(text);
+				if(ms.isValid()) {
+					auto *runs_model = qobject_cast<RunsTableModel*>(view()->tableModel());
+					Q_ASSERT(runs_model);
+					auto dt = getPlugin<EventPlugin>()->stageStartDateTime(runs_model->stageId())
+						.addMSecs(ms.msec());
+					model->setData(index, dt);
+				}
+			}
+		}
+		return;
+	}
+	Super::setModelData(editor, model, index);
 }
 
 void RunsTableItemDelegate::setHighlightedClassId(int class_id, int stage_id)

--- a/quickevent/app/quickevent/plugins/Runs/src/runstableitemdelegate.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstableitemdelegate.h
@@ -18,6 +18,10 @@ public:
 
 	void setHighlightedClassId(int class_id, int stage_id);
 	void reloadHighlightedClassId();
+
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 protected:
 	void paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
 private:

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
@@ -1,8 +1,10 @@
 #include "runstablemodel.h"
 
+#include "runsplugin.h"
+#include "../../Event/src/eventplugin.h"
+
 #include <quickevent/core/og/timems.h>
 #include <quickevent/core/si/siid.h>
-#include "../../Event/src/eventplugin.h"
 
 #include <qf/gui/log.h>
 #include <qf/gui/framework/mainwindow.h>
@@ -40,9 +42,11 @@ RunsTableModel::RunsTableModel(QObject *parent)
 	setColumn(col_runs_corridorTime, ColumnDefinition("runs.corridorTime", tr("Corridor")).setToolTip(tr("Time when the competitor entered start corridor")).setFormat(QStringLiteral("dd.MM.yyyy hh:mm:ss")));
 	setColumn(col_runs_checkTimeMs, ColumnDefinition("runs.checkTimeMs", tr("Check")).setCastType(qMetaTypeId<quickevent::core::og::TimeMs>()));
 	setColumn(col_runs_startTimeMs, ColumnDefinition("runs.startTimeMs", tr("Start")).setCastType(qMetaTypeId<quickevent::core::og::TimeMs>()));
-	setColumn(col_runs_timeMs, ColumnDefinition("runs.timeMs", tr("Time")).setCastType(qMetaTypeId<quickevent::core::og::TimeMs>()));
+	setColumn(col_runs_startGateTime, ColumnDefinition("runs.startGateTime", tr("Start gate")));
 	setColumn(col_runs_finishTimeMs, ColumnDefinition("runs.finishTimeMs", tr("Finish")).setCastType(qMetaTypeId<quickevent::core::og::TimeMs>()));
+	setColumn(col_runs_finishGateTime, ColumnDefinition("runs.finishGateTime", tr("Finish gate")));
 	setColumn(col_runs_penaltyTimeMs, ColumnDefinition("runs.penaltyTimeMs", tr("Penalty")).setCastType(qMetaTypeId<quickevent::core::og::TimeMs>()));
+	setColumn(col_runs_timeMs, ColumnDefinition("runs.timeMs", tr("Time")).setCastType(qMetaTypeId<quickevent::core::og::TimeMs>()));
 	setColumn(col_runFlags, ColumnDefinition("runFlags", tr("Run flags")).setReadOnly(true));
 	setColumn(col_cardFlags, ColumnDefinition("cardFlags", tr("Card flags")).setReadOnly(true));
 	setColumn(col_runs_rankingPos, ColumnDefinition("ranking", tr("Ranking pos")).setToolTip(tr("Runner's position in CZ ranking.")).setReadOnly(false));
@@ -51,6 +55,15 @@ RunsTableModel::RunsTableModel(QObject *parent)
 
 	connect(this, &RunsTableModel::dataChanged, this, &RunsTableModel::onDataChanged, Qt::QueuedConnection);
 	connect(qf::gui::framework::Application::instance(), &qf::gui::framework::Application::qxRecChng, this, &RunsTableModel::onQxRecChng, Qt::QueuedConnection);
+}
+
+void RunsTableModel::load(int stage_id, int class_id, bool show_offrace)
+{
+	m_stageId = stage_id;
+	auto qb = getPlugin<Runs::RunsPlugin>()->runsQuery(stage_id, class_id, show_offrace);
+	qfDebug() << qb.toString();
+	setQueryBuilder(qb, false);
+	reload();
 }
 
 Qt::ItemFlags RunsTableModel::flags(const QModelIndex &index) const
@@ -79,20 +92,22 @@ QVariant RunsTableModel::data(const QModelIndex &index, int role) const
 		}
 	}
 
-	if(index.column() == col_runs_corridorTime && role == Qt::DisplayRole) {
+	if((index.column() == col_runs_corridorTime
+	|| index.column() == col_runs_startGateTime
+	|| index.column() == col_runs_finishGateTime) && role == Qt::DisplayRole) {
 		QVariant raw = Super::data(index, Qt::EditRole);
 		if(raw.isNull() || !raw.isValid())
 			return QVariant();
-		QDateTime corridor_dt = raw.toDateTime();
-		if(!corridor_dt.isValid())
+		auto dt = raw.toDateTime();
+		if(!dt.isValid())
 			return QVariant();
-		int stage_id = getPlugin<EventPlugin>()->currentStageId();
-		QDateTime stage_start = getPlugin<EventPlugin>()->stageStartDateTime(stage_id);
+		QDateTime stage_start = getPlugin<EventPlugin>()->stageStartDateTime(m_stageId);
 		if(!stage_start.isValid())
 			return QVariant();
-		qint64 offset_ms = stage_start.msecsTo(corridor_dt);
-		if(offset_ms < 0)
+		qint64 offset_ms = stage_start.msecsTo(dt);
+		if(offset_ms < 0) {
 			return QVariant();
+		}
 		return quickevent::core::og::TimeMs(static_cast<int>(offset_ms)).toString();
 	}
 
@@ -259,23 +274,7 @@ Qt::DropActions RunsTableModel::supportedDropActions() const
 	//qfLogFuncFrame();
 	return Qt::MoveAction;// | Qt::CopyAction;
 }
-/*
-bool RunsTableModel::canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) const
-{
-	qfLogFuncFrame() << "row:" << row << "col:" << column << action << parent;
-	Q_UNUSED(action);
-	Q_UNUSED(row);
-	Q_UNUSED(parent);
 
-	if (!data->hasFormat(MIME_TYPE))
-		return false;
-
-	if (column > 0)
-		return false;
-	qfInfo() << "TRUE";
-	return true;
-}
-*/
 bool RunsTableModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent)
 {
 	// qfLogFuncFrame() << "row:" << row << "col:" << column << "parent:" << parent;
@@ -387,4 +386,3 @@ bool RunsTableModel::postRow(int row_no, bool throw_exc)
 	}
 	return ret;
 }
-

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
@@ -62,6 +62,7 @@ void RunsTableModel::load(int stage_id, int class_id, bool show_offrace)
 {
 	m_stageId = stage_id;
 	auto qb = getPlugin<Runs::RunsPlugin>()->runsQuery(stage_id, class_id, show_offrace);
+	qb.orderBy("runs.id");
 	qfDebug() << qb.toString();
 	setQueryBuilder(qb, false);
 	reload();
@@ -95,44 +96,54 @@ QVariant RunsTableModel::data(const QModelIndex &index, int role) const
 
 	if((index.column() == col_runs_corridorTime
 	|| index.column() == col_runs_startGateTime
-	|| index.column() == col_runs_finishGateTime) && role == Qt::DisplayRole) {
-		QVariant raw = Super::data(index, Qt::EditRole);
-		if(raw.isNull() || !raw.isValid())
-			return QVariant();
-		auto dt = raw.toDateTime();
-		if(!dt.isValid())
-			return QVariant();
-		QDateTime stage_start = getPlugin<EventPlugin>()->stageStartDateTime(m_stageId);
-		if(!stage_start.isValid())
-			return QVariant();
-		qint64 offset_ms = stage_start.msecsTo(dt);
-		if(offset_ms < 0) {
-			return QVariant();
-		}
-		return quickevent::core::og::TimeMs(static_cast<int>(offset_ms)).toString();
-	}
-
-	if((index.column() == col_runs_startGateTime || index.column() == col_runs_finishGateTime) && role == Qt::BackgroundRole) {
+	|| index.column() == col_runs_finishGateTime)) {
 		auto *event_plugin = getPlugin<EventPlugin>();
-		const auto &config = event_plugin->appDbConfig().radioSenderConfig();
-		const bool is_start = index.column() == col_runs_startGateTime;
-		const int time_col = is_start ? col_runs_startTimeMs : col_runs_finishTimeMs;
-		const int tolerance = is_start ? config.startToleranceMs : config.finishToleranceMs;
-		auto check_gate = [&](const QModelIndex &idx, int tc, int tol) -> QVariant {
-			auto gate_time = Super::data(idx, Qt::EditRole).toDateTime();
-			if(!gate_time.isValid()) {
+		if (role == Qt::DisplayRole) {
+			QVariant raw = Super::data(index, Qt::EditRole);
+			if(raw.isNull() || !raw.isValid())
+				return QVariant();
+			auto dt = raw.toDateTime();
+			if(!dt.isValid())
+				return QVariant();
+			QDateTime stage_start = event_plugin->stageStartDateTime(m_stageId);
+			if(!stage_start.isValid())
+				return QVariant();
+			qint64 offset_ms = stage_start.msecsTo(dt);
+			return quickevent::core::og::TimeMs(static_cast<int>(offset_ms)).toString();
+		}
+		if (role == Qt::ToolTipRole) {
+			QVariant raw = Super::data(index, Qt::EditRole);
+			auto dt = raw.toDateTime();
+			if(!dt.isValid()) {
 				return QVariant();
 			}
-			auto time_v = Super::data(idx.sibling(idx.row(), tc), Qt::EditRole);
-			if(!time_v.isValid()) {
-				return QVariant();
+			dt = dt.toLocalTime();
+			return dt.toString(Qt::ISODateWithMs);
+		}
+		if(index.column() == col_runs_startGateTime || index.column() == col_runs_finishGateTime) {
+			if (role == Qt::BackgroundRole) {
+				const auto &config = event_plugin->appDbConfig().radioSenderConfig();
+				const bool is_start = index.column() == col_runs_startGateTime;
+				const int time_col = is_start ? col_runs_startTimeMs : col_runs_finishTimeMs;
+				const int tolerance = is_start ? config.startToleranceMs : config.finishToleranceMs;
+				auto check_gate = [&](const QModelIndex &idx, int tc, int tol) -> QVariant {
+					auto gate_time = Super::data(idx, Qt::EditRole).toDateTime();
+					if(!gate_time.isValid()) {
+						return QVariant();
+					}
+					auto time_v = Super::data(idx.sibling(idx.row(), tc), Qt::EditRole);
+					if(!time_v.isValid()) {
+						return QVariant();
+					}
+					auto time_msec = time_v.toInt();
+					auto ref_time = event_plugin->stageStartDateTime(m_stageId).addMSecs(time_msec);
+					const bool is_ok = std::abs(gate_time.msecsTo(ref_time)) <= tol;
+					return is_ok ? QColor("lightgreen") : QColor("salmon");
+				};
+				return check_gate(index, time_col, tolerance);
 			}
-			auto time_msec = time_v.toInt();
-			auto ref_time = event_plugin->stageStartDateTime(m_stageId).addMSecs(time_msec);
-			const bool is_ok = std::abs(gate_time.msecsTo(ref_time)) <= tol;
-			return is_ok ? QColor("lightgreen") : QColor("salmon");
-		};
-		return check_gate(index, time_col, tolerance);
+		}
+		return QVariant();
 	}
 
 	return Super::data(index, role);

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
@@ -18,8 +18,7 @@
 #include <qf/core/assert.h>
 
 #include <QMimeData>
-
-#include <cmath>
+#include <QTimer>
 
 using qf::gui::framework::getPlugin;
 using Event::EventPlugin;
@@ -221,6 +220,8 @@ QVariant RunsTableModel::value(int row_ix, int column_ix) const
 	return Super::value(row_ix, column_ix);
 }
 
+
+
 bool RunsTableModel::setValue(int row_ix, int column_ix, const QVariant &val)
 {
 	//qfInfo() << column_ix << val << val.typeName() << "is null:" << val.isNull();
@@ -235,41 +236,18 @@ bool RunsTableModel::setValue(int row_ix, int column_ix, const QVariant &val)
 		}
 		return Super::setValue(row_ix, column_ix, is_running);
 	}
-	// Setting any of these five recalculates timeMs.
-	// timeMs = effective_finish - effective_start + penaltyTimeMs
-	// effective_start  = startGateTime (as ms from stage start) if within tolerance, else startTimeMs
-	// effective_finish = finishGateTime (as ms from stage start) if within tolerance, else finishTimeMs
 	if(column_ix == col_runs_finishTimeMs
 			|| column_ix == col_runs_startTimeMs
 			|| column_ix == col_runs_penaltyTimeMs
 			|| column_ix == col_runs_startGateTime
 			|| column_ix == col_runs_finishGateTime) {
 		bool ret = Super::setValue(row_ix, column_ix, val);
-		const QVariant finish_ms_v = value(row_ix, col_runs_finishTimeMs);
-		const QVariant start_ms_v = value(row_ix, col_runs_startTimeMs);
-		if(finish_ms_v.isNull() || start_ms_v.isNull()) {
-			Super::setValue(row_ix, col_runs_timeMs, QVariant());
-		}
-		else {
-			auto *event_plugin = getPlugin<EventPlugin>();
-			const QDateTime stage_start = event_plugin->stageStartDateTime(m_stageId);
-			const auto &config = event_plugin->appDbConfig().radioSenderConfig();
-			const qint64 start_ms = start_ms_v.toLongLong();
-			const qint64 finish_ms = finish_ms_v.toLongLong();
-			const auto start_gate_dt = value(row_ix, col_runs_startGateTime).toDateTime();
-			const auto finish_gate_dt = value(row_ix, col_runs_finishGateTime).toDateTime();
-			const qint64 start_gate_msec = stage_start.msecsTo(start_gate_dt);
-			const qint64 finish_gate_msec = stage_start.msecsTo(finish_gate_dt);
-			const bool use_start_gate = start_gate_dt.isValid() && start_ms_v.isValid()
-				&& std::abs(start_gate_msec - start_ms) <= config.startToleranceMs;
-			const bool use_finish_gate = finish_gate_dt.isValid() && finish_ms_v.isValid()
-				&& std::abs(finish_gate_msec - finish_ms) <= config.finishToleranceMs;
-			const int penalty_ms = value(row_ix, col_runs_penaltyTimeMs).toInt();
-			const qint64 time_ms = (use_finish_gate ? finish_gate_msec : finish_ms)
-				- (use_start_gate ? start_gate_msec : start_ms)
-				+ penalty_ms;
-			Super::setValue(row_ix, col_runs_timeMs, time_ms > 0 ? QVariant(time_ms) : QVariant());
-		}
+		const int run_id = value(row_ix, col_runs_id).toInt();
+		QTimer::singleShot(0, this, [run_id]() {
+			// computeStageTime takes values from SQL
+			// wait to let model post edited value
+			getPlugin<Runs::RunsPlugin>()->computeStageTime(run_id);
+		});
 		return ret;
 	}
 	return Super::setValue(row_ix, column_ix, val);

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
@@ -3,6 +3,7 @@
 #include "runsplugin.h"
 #include "../../Event/src/eventplugin.h"
 
+#include <qnamespace.h>
 #include <quickevent/core/og/timems.h>
 #include <quickevent/core/si/siid.h>
 
@@ -109,6 +110,29 @@ QVariant RunsTableModel::data(const QModelIndex &index, int role) const
 			return QVariant();
 		}
 		return quickevent::core::og::TimeMs(static_cast<int>(offset_ms)).toString();
+	}
+
+	if((index.column() == col_runs_startGateTime || index.column() == col_runs_finishGateTime) && role == Qt::BackgroundRole) {
+		auto *event_plugin = getPlugin<EventPlugin>();
+		const auto &config = event_plugin->appDbConfig().radioSenderConfig();
+		const bool is_start = index.column() == col_runs_startGateTime;
+		const int time_col = is_start ? col_runs_startTimeMs : col_runs_finishTimeMs;
+		const int tolerance = is_start ? config.startToleranceMs : config.finishToleranceMs;
+		auto check_gate = [&](const QModelIndex &idx, int tc, int tol) -> QVariant {
+			auto gate_time = Super::data(idx, Qt::EditRole).toDateTime();
+			if(!gate_time.isValid()) {
+				return QVariant();
+			}
+			auto time_v = Super::data(idx.sibling(idx.row(), tc), Qt::EditRole);
+			if(!time_v.isValid()) {
+				return QVariant();
+			}
+			auto time_msec = time_v.toInt();
+			auto ref_time = event_plugin->stageStartDateTime(m_stageId).addMSecs(time_msec);
+			const bool is_ok = std::abs(gate_time.msecsTo(ref_time)) <= tol;
+			return is_ok ? QColor("lightgreen") : QColor("salmon");
+		};
+		return check_gate(index, time_col, tolerance);
 	}
 
 	return Super::data(index, role);

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
@@ -19,6 +19,8 @@
 
 #include <QMimeData>
 
+#include <cmath>
+
 using qf::gui::framework::getPlugin;
 using Event::EventPlugin;
 
@@ -233,19 +235,39 @@ bool RunsTableModel::setValue(int row_ix, int column_ix, const QVariant &val)
 		}
 		return Super::setValue(row_ix, column_ix, is_running);
 	}
-	// Setting any of these three recalculates timeMs = finishTimeMs - startTimeMs + penaltyTimeMs.
+	// Setting any of these five recalculates timeMs.
+	// timeMs = effective_finish - effective_start + penaltyTimeMs
+	// effective_start  = startGateTime (as ms from stage start) if within tolerance, else startTimeMs
+	// effective_finish = finishGateTime (as ms from stage start) if within tolerance, else finishTimeMs
 	if(column_ix == col_runs_finishTimeMs
 			|| column_ix == col_runs_startTimeMs
-			|| column_ix == col_runs_penaltyTimeMs) {
+			|| column_ix == col_runs_penaltyTimeMs
+			|| column_ix == col_runs_startGateTime
+			|| column_ix == col_runs_finishGateTime) {
 		bool ret = Super::setValue(row_ix, column_ix, val);
-		QVariant finish_ms = value(row_ix, col_runs_finishTimeMs);
-		QVariant start_ms = value(row_ix, col_runs_startTimeMs);
-		if(finish_ms.isNull() || start_ms.isNull()) {
+		const QVariant finish_ms_v = value(row_ix, col_runs_finishTimeMs);
+		const QVariant start_ms_v = value(row_ix, col_runs_startTimeMs);
+		if(finish_ms_v.isNull() || start_ms_v.isNull()) {
 			Super::setValue(row_ix, col_runs_timeMs, QVariant());
 		}
 		else {
-			int penalty_ms = value(row_ix, col_runs_penaltyTimeMs).toInt();
-			int time_ms = finish_ms.toInt() - start_ms.toInt() + penalty_ms;
+			auto *event_plugin = getPlugin<EventPlugin>();
+			const QDateTime stage_start = event_plugin->stageStartDateTime(m_stageId);
+			const auto &config = event_plugin->appDbConfig().radioSenderConfig();
+			const qint64 start_ms = start_ms_v.toLongLong();
+			const qint64 finish_ms = finish_ms_v.toLongLong();
+			const auto start_gate_dt = value(row_ix, col_runs_startGateTime).toDateTime();
+			const auto finish_gate_dt = value(row_ix, col_runs_finishGateTime).toDateTime();
+			const qint64 start_gate_msec = stage_start.msecsTo(start_gate_dt);
+			const qint64 finish_gate_msec = stage_start.msecsTo(finish_gate_dt);
+			const bool use_start_gate = start_gate_dt.isValid() && start_ms_v.isValid()
+				&& std::abs(start_gate_msec - start_ms) <= config.startToleranceMs;
+			const bool use_finish_gate = finish_gate_dt.isValid() && finish_ms_v.isValid()
+				&& std::abs(finish_gate_msec - finish_ms) <= config.finishToleranceMs;
+			const int penalty_ms = value(row_ix, col_runs_penaltyTimeMs).toInt();
+			const qint64 time_ms = (use_finish_gate ? finish_gate_msec : finish_ms)
+				- (use_start_gate ? start_gate_msec : start_ms)
+				+ penalty_ms;
 			Super::setValue(row_ix, col_runs_timeMs, time_ms > 0 ? QVariant(time_ms) : QVariant());
 		}
 		return ret;

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
@@ -135,7 +135,7 @@ QVariant RunsTableModel::data(const QModelIndex &index, int role) const
 			if(!stage_start.isValid())
 				return QVariant();
 			qint64 offset_ms = stage_start.msecsTo(dt);
-			return quickevent::core::og::TimeMs(static_cast<int>(offset_ms)).toString(':', '.');
+			return quickevent::core::og::TimeMs(static_cast<int>(offset_ms)).toString();
 		}
 		if(index.column() == col_runs_startGateTime || index.column() == col_runs_finishGateTime) {
 			if (role == Qt::BackgroundRole) {
@@ -233,74 +233,24 @@ bool RunsTableModel::setValue(int row_ix, int column_ix, const QVariant &val)
 		}
 		return Super::setValue(row_ix, column_ix, is_running);
 	}
-	if(column_ix == col_runs_finishTimeMs) {
+	// Setting any of these three recalculates timeMs = finishTimeMs - startTimeMs + penaltyTimeMs.
+	if(column_ix == col_runs_finishTimeMs
+			|| column_ix == col_runs_startTimeMs
+			|| column_ix == col_runs_penaltyTimeMs) {
+		bool ret = Super::setValue(row_ix, column_ix, val);
+		QVariant finish_ms = value(row_ix, col_runs_finishTimeMs);
 		QVariant start_ms = value(row_ix, col_runs_startTimeMs);
-		if(val.isNull()) {
+		if(finish_ms.isNull() || start_ms.isNull()) {
 			Super::setValue(row_ix, col_runs_timeMs, QVariant());
 		}
 		else {
-			if(!start_ms.isNull()) {
-				int penalty_ms = value(row_ix, col_runs_penaltyTimeMs).toInt();
-				int time_ms = val.toInt() - start_ms.toInt() + penalty_ms;
-				if(time_ms > 0) {
-					Super::setValue(row_ix, col_runs_timeMs, time_ms);
-				}
-				else {
-					Super::setValue(row_ix, col_runs_timeMs, QVariant());
-				}
-			}
-		}
-		return Super::setValue(row_ix, column_ix, val);
-	}
-	if(column_ix == col_runs_penaltyTimeMs) {
-		int penalty_ms = val.toInt();
-		int old_penalty_ms = Super::value(row_ix, col_runs_penaltyTimeMs).toInt();
-		int time_ms = value(row_ix, col_runs_timeMs).toInt();
-		if(time_ms > 0) {
-			time_ms = time_ms - old_penalty_ms + penalty_ms;
-			Super::setValue(row_ix, col_runs_timeMs, time_ms);
-		}
-		return Super::setValue(row_ix, column_ix, val);
-	}
-	if(column_ix == col_runs_timeMs) {
-		int rt = val.toInt();
-		if(rt == 0) {
-			/// run time cannot be 0
-			Super::setValue(row_ix, col_runs_finishTimeMs, QVariant());
-			Super::setValue(row_ix, col_runs_penaltyTimeMs, QVariant());
-			return Super::setValue(row_ix, column_ix, QVariant());
-		}
-		QVariant start_ms = value(row_ix, col_runs_startTimeMs);
-		if(!start_ms.isNull()) {
 			int penalty_ms = value(row_ix, col_runs_penaltyTimeMs).toInt();
-			int finish_ms = val.toInt() + start_ms.toInt() - penalty_ms;
-			if(finish_ms > 0) {
-				Super::setValue(row_ix, col_runs_finishTimeMs, finish_ms);
-			}
-			else {
-				Super::setValue(row_ix, col_runs_finishTimeMs, QVariant());
-			}
+			int time_ms = finish_ms.toInt() - start_ms.toInt() + penalty_ms;
+			Super::setValue(row_ix, col_runs_timeMs, time_ms > 0 ? QVariant(time_ms) : QVariant());
 		}
-		return Super::setValue(row_ix, column_ix, val);
+		return ret;
 	}
-	if(column_ix == col_runs_startTimeMs) {
-		if(!val.isNull()) {
-			int start_ms = val.toInt();
-			int finish_ms = value(row_ix, col_runs_finishTimeMs).toInt();
-			int penalty_ms = value(row_ix, col_runs_penaltyTimeMs).toInt();
-			int time_ms = value(row_ix, col_runs_timeMs).toInt();
-			if(finish_ms > 0) {
-				int time_ms = finish_ms - start_ms + penalty_ms;
-				Super::setValue(row_ix, col_runs_timeMs, time_ms);
-			}
-			else if(time_ms > penalty_ms) {
-				finish_ms = start_ms + time_ms - penalty_ms;
-				Super::setValue(row_ix, col_runs_finishTimeMs, finish_ms);
-			}
-		}
-	}
-	bool ret = Super::setValue(row_ix, column_ix, val);
-	return ret;
+	return Super::setValue(row_ix, column_ix, val);
 }
 
 static const auto MIME_TYPE = QStringLiteral("application/quickevent.startTime");
@@ -400,8 +350,9 @@ void RunsTableModel::switchStartTimes(int r1, int r2)
 void RunsTableModel::onDataChanged(const QModelIndex &top_left, const QModelIndex &bottom_right, const QVector<int> &roles)
 {
 	Q_UNUSED(roles)
-	if(top_left.column() <= RunsTableModel::col_runs_siId && bottom_right.column() >= RunsTableModel::col_runs_siId)
+	if(top_left.column() <= RunsTableModel::col_runs_siId && bottom_right.column() >= RunsTableModel::col_runs_siId) {
 		emit runnerSiIdEdited();
+	}
 }
 
 void RunsTableModel::onQxRecChng(const qf::core::sql::QxRecChng &recchng, QObject *source)

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
@@ -35,11 +35,11 @@ RunsTableModel::RunsTableModel(QObject *parent)
 	setColumn(col_classes_name, ColumnDefinition("classes.name", tr("Class")));
 	setColumn(col_startNumber, ColumnDefinition("startNumber", tr("SN", "start number")).setToolTip(tr("Start number")));
 	setColumn(col_course_id, ColumnDefinition("runs.courseId", tr("Course")));
-	setColumn(col_competitors_siId, ColumnDefinition("competitors.siId", tr("SI")).setToolTip(tr("Registered SI")).setReadOnly(true));
+	setColumn(col_competitors_siId, ColumnDefinition("competitors.siId", tr("SI reg")).setToolTip(tr("Registered SI")).setReadOnly(true));
 	setColumn(col_competitorName, ColumnDefinition("competitorName", tr("Name")));
 	setColumn(col_registration, ColumnDefinition("registration", tr("Reg")));
 	setColumn(col_runs_license, ColumnDefinition("licence", tr("Lic")).setToolTip(tr("License")));
-	setColumn(col_runs_siId, ColumnDefinition("runs.siId", tr("SI")).setToolTip(tr("Actual SI")).setCastType(qMetaTypeId<quickevent::core::si::SiId>()));
+	setColumn(col_runs_siId, ColumnDefinition("runs.siId", tr("SI")).setToolTip(tr("Run SI")).setCastType(qMetaTypeId<quickevent::core::si::SiId>()));
 	setColumn(col_runs_corridorTime, ColumnDefinition("runs.corridorTime", tr("Corridor")).setToolTip(tr("Time when the competitor entered start corridor")).setFormat(QStringLiteral("dd.MM.yyyy hh:mm:ss")));
 	setColumn(col_runs_checkTimeMs, ColumnDefinition("runs.checkTimeMs", tr("Check")).setCastType(qMetaTypeId<quickevent::core::og::TimeMs>()));
 	setColumn(col_runs_startTimeMs, ColumnDefinition("runs.startTimeMs", tr("Start")).setCastType(qMetaTypeId<quickevent::core::og::TimeMs>()));

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.cpp
@@ -92,6 +92,34 @@ QVariant RunsTableModel::data(const QModelIndex &index, int role) const
 			auto leg = value(index.row(), "runs.leg").toInt();
 			return QStringLiteral("%1.%2").arg(start_number).arg(leg);
 		}
+		return Super::data(index, role);
+	}
+	if((index.column() == col_runs_startTimeMs
+	|| index.column() == col_runs_checkTimeMs
+	|| index.column() == col_runs_finishTimeMs
+	|| index.column() == col_runs_timeMs)
+	&& role == Qt::ToolTipRole) {
+		QVariant raw = Super::data(index, Qt::EditRole);
+		if(raw.isNull() || !raw.isValid())
+			return QVariant();
+		auto *event_plugin = getPlugin<EventPlugin>();
+		auto dt = event_plugin->stageStartDateTime(m_stageId)
+			.addMSecs(raw.toInt())
+			.toLocalTime();
+		return dt.time().toString(Qt::ISODateWithMs);
+	}
+
+	if((index.column() == col_runs_corridorTime
+	|| index.column() == col_runs_startGateTime
+	|| index.column() == col_runs_finishGateTime)
+	&& role == Qt::ToolTipRole) {
+		QVariant raw = Super::data(index, Qt::EditRole);
+		if(raw.isNull() || !raw.isValid())
+			return QVariant();
+		auto time = raw.toDateTime().toLocalTime().time();
+		if (time.msec() == 0)
+			return time.toString(Qt::ISODateWithMs);
+		return time.addMSecs(raw.toInt()).toString(Qt::ISODateWithMs);
 	}
 
 	if((index.column() == col_runs_corridorTime
@@ -100,8 +128,6 @@ QVariant RunsTableModel::data(const QModelIndex &index, int role) const
 		auto *event_plugin = getPlugin<EventPlugin>();
 		if (role == Qt::DisplayRole) {
 			QVariant raw = Super::data(index, Qt::EditRole);
-			if(raw.isNull() || !raw.isValid())
-				return QVariant();
 			auto dt = raw.toDateTime();
 			if(!dt.isValid())
 				return QVariant();
@@ -109,16 +135,7 @@ QVariant RunsTableModel::data(const QModelIndex &index, int role) const
 			if(!stage_start.isValid())
 				return QVariant();
 			qint64 offset_ms = stage_start.msecsTo(dt);
-			return quickevent::core::og::TimeMs(static_cast<int>(offset_ms)).toString();
-		}
-		if (role == Qt::ToolTipRole) {
-			QVariant raw = Super::data(index, Qt::EditRole);
-			auto dt = raw.toDateTime();
-			if(!dt.isValid()) {
-				return QVariant();
-			}
-			dt = dt.toLocalTime();
-			return dt.toString(Qt::ISODateWithMs);
+			return quickevent::core::og::TimeMs(static_cast<int>(offset_ms)).toString(':', '.');
 		}
 		if(index.column() == col_runs_startGateTime || index.column() == col_runs_finishGateTime) {
 			if (role == Qt::BackgroundRole) {
@@ -143,7 +160,7 @@ QVariant RunsTableModel::data(const QModelIndex &index, int role) const
 				return check_gate(index, time_col, tolerance);
 			}
 		}
-		return QVariant();
+		return Super::data(index, role);
 	}
 
 	return Super::data(index, role);

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.h
@@ -69,6 +69,7 @@ public:
 private:
 	void onDataChanged(const QModelIndex &top_left, const QModelIndex &bottom_right, const QVector<int> &roles);
 	void onQxRecChng(const qf::core::sql::QxRecChng &recchng, QObject *source);
+
 private:
     int m_stageId = 1;
 };

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.h
@@ -27,7 +27,9 @@ public:
 		col_runs_corridorTime,
 		col_runs_checkTimeMs,
 		col_runs_startTimeMs,
+		col_runs_startGateTime,
 		col_runs_finishTimeMs,
+		col_runs_finishGateTime,
 		col_runs_penaltyTimeMs,
 		col_runs_timeMs,
 		col_runFlags,
@@ -43,7 +45,6 @@ public:
 	int columnCount(const QModelIndex &) const override { return col_COUNT; }
 	Qt::ItemFlags flags(const QModelIndex &index) const override;
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-	//bool setData(const QModelIndex &index, const QVariant &value, int role) override;
 
 	using Super::value;
 	QVariant value(int row_ix, int column_ix) const override;
@@ -51,6 +52,8 @@ public:
 	bool setValue(int row_ix, int column_ix, const QVariant &val) override;
 
 	bool postRow(int row_no, bool throw_exc) override;
+
+	void load(int stage_id, int class_id, bool show_offrace);
 
 	QStringList mimeTypes() const override;
 	QMimeData *mimeData(const QModelIndexList &indexes) const override;
@@ -65,6 +68,8 @@ public:
 private:
 	void onDataChanged(const QModelIndex &top_left, const QModelIndex &bottom_right, const QVector<int> &roles);
 	void onQxRecChng(const qf::core::sql::QxRecChng &recchng, QObject *source);
+private:
+    int m_stageId = 1;
 };
 
 #endif // RUNSTABLEMODEL_H

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablemodel.h
@@ -53,6 +53,7 @@ public:
 
 	bool postRow(int row_no, bool throw_exc) override;
 
+	int stageId() const { return m_stageId; }
 	void load(int stage_id, int class_id, bool show_offrace);
 
 	QStringList mimeTypes() const override;

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.cpp
@@ -60,9 +60,8 @@ RunsTableWidget::RunsTableWidget(QWidget *parent) :
 	connect(event_plugin, &EventPlugin::eventOpenChanged, this, [this, event_plugin](bool is_open) {
 		if(is_open) {
 			auto hidden_columns = RunsPlugin::loadRunsTableHiddenColumns();
-			for(int column = 0; column < RunsTableModel::col_COUNT; ++column) {
-				setColumnVisible(column, !hidden_columns.contains(m_runsModel->columnDefinition(column).fieldName()));
-			}
+			setColumnsHidden(hidden_columns);
+			setColumnsOrder(RunsPlugin::loadRunsTableColumnOrder());
 		}
 		if (is_open && !event_plugin->appDbConfig().eventConfig().isRelays() && !m_courseItemDelegate) {
 			m_courseItemDelegate = new CourseItemDelegate(ui->tblRuns);
@@ -241,9 +240,33 @@ qf::gui::TableView *RunsTableWidget::tableView()
 	return ui->tblRuns;
 }
 
-void RunsTableWidget::setColumnVisible(int column, bool visible)
+void RunsTableWidget::setColumnsHidden(const QStringList &hidden_field_names)
 {
-	ui->tblRuns->horizontalHeader()->setSectionHidden(column, !visible);
+	for(const auto &field_name : hidden_field_names) {
+		int col = m_runsModel->columnIndex(field_name);
+		if(col >= 0) {
+			ui->tblRuns->horizontalHeader()->setSectionHidden(col, true);
+		}
+	}
+}
+
+void RunsTableWidget::setColumnsOrder(const QStringList &ordered_field_names)
+{
+	if(ordered_field_names.isEmpty())
+		return;
+	auto *hh = ui->tblRuns->horizontalHeader();
+	const int col_count = RunsTableModel::col_COUNT;
+	for(int target_visual = 0; target_visual < ordered_field_names.size() && target_visual < col_count; ++target_visual) {
+		const auto &field_name = ordered_field_names[target_visual];
+		for(int logical = 0; logical < col_count; ++logical) {
+			if(m_runsModel->columnDefinition(logical).fieldName() == field_name) {
+				const int current_visual = hh->visualIndex(logical);
+				if(current_visual != target_visual)
+					hh->moveSection(current_visual, target_visual);
+				break;
+			}
+		}
+	}
 }
 
 QMap<int, QString> RunsTableWidget::definedCourses()

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.cpp
@@ -58,6 +58,17 @@ RunsTableWidget::RunsTableWidget(QWidget *parent) :
 	ui->tblRuns->setItemDelegate(m_runsTableItemDelegate);
 	auto *event_plugin = getPlugin<Event::EventPlugin>();
 	connect(event_plugin, &EventPlugin::eventOpenChanged, this, [this, event_plugin](bool is_open) {
+		if(is_open) {
+			qf::core::sql::Query q;
+			q.prepare("SELECT cvalue FROM config WHERE ckey='runs.hiddenColumns'", qf::core::Exception::Throw);
+			q.exec(qf::core::Exception::Throw);
+			if(q.next()) {
+				const auto hidden_columns = q.value("cvalue").toString().split(',', Qt::SkipEmptyParts);
+				for(int column = 0; column < RunsTableModel::col_COUNT; ++column) {
+					setColumnVisible(column, !hidden_columns.contains(m_runsModel->columnDefinition(column).fieldName()));
+				}
+			}
+		}
 		if (is_open && !event_plugin->appDbConfig().eventConfig().isRelays() && !m_courseItemDelegate) {
 			m_courseItemDelegate = new CourseItemDelegate(ui->tblRuns);
 			m_courseItemDelegate->setNullText(tr("Implicit"));
@@ -233,6 +244,11 @@ void RunsTableWidget::reload()
 qf::gui::TableView *RunsTableWidget::tableView()
 {
 	return ui->tblRuns;
+}
+
+void RunsTableWidget::setColumnVisible(int column, bool visible)
+{
+	ui->tblRuns->horizontalHeader()->setSectionHidden(column, !visible);
 }
 
 QMap<int, QString> RunsTableWidget::definedCourses()

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.cpp
@@ -182,11 +182,8 @@ void RunsTableWidget::reload(int stage_id, int class_id, bool show_offrace, cons
 	if (!is_relays && m_courseItemDelegate) {
 		m_courseItemDelegate->setCourses(definedCourses());
 	}
-	auto qb = getPlugin<RunsPlugin>()->runsQuery(stage_id, class_id, show_offrace);
-	qfDebug() << qb.toString();
 	m_runsTableItemDelegate->setHighlightedClassId(class_id, stage_id);
-	m_runsModel->setQueryBuilder(qb, false);
-	m_runsModel->reload();
+	m_runsModel->load(stage_id, class_id, show_offrace);
 	updateStartTimeHighlight();
 
 	QHeaderView *hh = ui->tblRuns->horizontalHeader();
@@ -242,11 +239,9 @@ qf::gui::TableView *RunsTableWidget::tableView()
 
 void RunsTableWidget::setColumnsHidden(const QStringList &hidden_field_names)
 {
-	for(const auto &field_name : hidden_field_names) {
-		int col = m_runsModel->columnIndex(field_name);
-		if(col >= 0) {
-			ui->tblRuns->horizontalHeader()->setSectionHidden(col, true);
-		}
+    for (int i = 0; i < m_runsModel->columnCount({}); ++i) {
+        auto field_name = m_runsModel->columnDefinition(i).fieldName();
+		ui->tblRuns->horizontalHeader()->setSectionHidden(i, hidden_field_names.contains(field_name));
 	}
 }
 

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.cpp
@@ -51,7 +51,7 @@ RunsTableWidget::RunsTableWidget(QWidget *parent) :
 	// ui->tblRuns->setEditRowsMenuSectionEnabled(false);
 	ui->tblRuns->setCloneRowEnabled(false);
 	ui->tblRuns->setDirtyRowsMenuSectionEnabled(false);
-	ui->tblRuns->setPersistentSettingsId("tblRuns");
+	ui->tblRuns->setPersistentSettingsId({}); // controlled by Runs settings
 	ui->tblRuns->setRowEditorMode(qfw::TableView::EditRowsMixed);
 	ui->tblRuns->setInlineEditSaveStrategy(qfw::TableView::OnEditedValueCommit);
 	m_runsTableItemDelegate = new RunsTableItemDelegate(ui->tblRuns);

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.cpp
@@ -59,14 +59,9 @@ RunsTableWidget::RunsTableWidget(QWidget *parent) :
 	auto *event_plugin = getPlugin<Event::EventPlugin>();
 	connect(event_plugin, &EventPlugin::eventOpenChanged, this, [this, event_plugin](bool is_open) {
 		if(is_open) {
-			qf::core::sql::Query q;
-			q.prepare("SELECT cvalue FROM config WHERE ckey='runs.hiddenColumns'", qf::core::Exception::Throw);
-			q.exec(qf::core::Exception::Throw);
-			if(q.next()) {
-				const auto hidden_columns = q.value("cvalue").toString().split(',', Qt::SkipEmptyParts);
-				for(int column = 0; column < RunsTableModel::col_COUNT; ++column) {
-					setColumnVisible(column, !hidden_columns.contains(m_runsModel->columnDefinition(column).fieldName()));
-				}
+			auto hidden_columns = RunsPlugin::loadRunsTableHiddenColumns();
+			for(int column = 0; column < RunsTableModel::col_COUNT; ++column) {
+				setColumnVisible(column, !hidden_columns.contains(m_runsModel->columnDefinition(column).fieldName()));
 			}
 		}
 		if (is_open && !event_plugin->appDbConfig().eventConfig().isRelays() && !m_courseItemDelegate) {
@@ -448,5 +443,3 @@ void RunsTableWidget::onBadTableDataInput(const QString &message)
 {
 	qf::gui::dialogs::MessageBox::showError(this, message);
 }
-
-

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.h
@@ -27,7 +27,8 @@ public:
 
 	RunsTableModel* runsModel() {return m_runsModel;}
 	qf::gui::TableView* tableView();
-	void setColumnVisible(int column, bool visible);
+	void setColumnsHidden(const QStringList &hidden_field_names);
+	void setColumnsOrder(const QStringList &ordered_field_names);
 
 	Q_SIGNAL void editCompetitorRequest(int competitor_id, int mode);
 private:
@@ -43,4 +44,3 @@ private:
 	RunsTableItemDelegate *m_runsTableItemDelegate;
 	CourseItemDelegate *m_courseItemDelegate = nullptr;
 };
-

--- a/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runstablewidget.h
@@ -27,6 +27,7 @@ public:
 
 	RunsTableModel* runsModel() {return m_runsModel;}
 	qf::gui::TableView* tableView();
+	void setColumnVisible(int column, bool visible);
 
 	Q_SIGNAL void editCompetitorRequest(int competitor_id, int mode);
 private:

--- a/quickevent/app/quickevent/plugins/Runs/src/runswidget.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runswidget.h
@@ -12,16 +12,8 @@ class QTextStream;
 class QLabel;
 class QToolButton;
 
-namespace qf {
-namespace core {
-namespace model {
-class SqlTableModel;
-}
-}
-namespace gui {
-class ForeignKeyComboBox;
-}
-}
+namespace qf::core::model { class SqlTableModel; }
+namespace qf::gui { class ForeignKeyComboBox; }
 
 namespace Event {
 class EventPlugin;
@@ -31,16 +23,14 @@ namespace Ui {
 class RunsWidget;
 }
 
-class ThisPartWidget;
-
 class RunsWidget : public QFrame
 {
 	Q_OBJECT
 private:
-	typedef QFrame Super;
+	using Super = QFrame;
 public:
 	explicit RunsWidget(QWidget *parent = nullptr);
-	~RunsWidget() Q_DECL_OVERRIDE;
+	~RunsWidget() override;
 
 	void settleDownInPartWidget(::PartWidget *part_widget);
 

--- a/quickevent/app/quickevent/plugins/Speaker/src/speakerplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Speaker/src/speakerplugin.cpp
@@ -24,7 +24,7 @@ SpeakerPlugin::SpeakerPlugin(QObject *parent)
 void SpeakerPlugin::onInstalled()
 {
 	qfLogFuncFrame();
-	m_partWidget = qff::initPluginWidget<SpeakerWidget, PartWidget>(tr("&Speaker"), featureId());
+	qff::initPluginWidget<SpeakerWidget, PartWidget>(tr("&Speaker"), featureId());
 }
 
 }

--- a/quickevent/app/quickevent/plugins/Speaker/src/speakerwidget.h
+++ b/quickevent/app/quickevent/plugins/Speaker/src/speakerwidget.h
@@ -13,15 +13,13 @@ namespace qf::gui { class ForeignKeyComboBox; }
 namespace quickevent::gui::og { class SqlTableModel; }
 namespace quickevent::core::si { class PunchRecord; }
 
-class ThisPartWidget;
-
 class SpeakerWidget : public QFrame
 {
 	Q_OBJECT
 private:
 	typedef QFrame Super;
 public:
-	explicit SpeakerWidget(QWidget *parent = 0);
+	explicit SpeakerWidget(QWidget *parent = nullptr);
 	~SpeakerWidget() Q_DECL_OVERRIDE;
 
 	void settleDownInPartWidget(::PartWidget *part_widget);

--- a/quickevent/app/quickevent/src/appversion.h
+++ b/quickevent/app/quickevent/src/appversion.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#define APP_VERSION "3.6.1"
+#define APP_VERSION "3.6.2"

--- a/quickevent/app/quickevent/src/appversion.h
+++ b/quickevent/app/quickevent/src/appversion.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#define APP_VERSION "3.5.9"
+#define APP_VERSION "3.6.0"
 

--- a/quickevent/app/quickevent/src/appversion.h
+++ b/quickevent/app/quickevent/src/appversion.h
@@ -1,4 +1,3 @@
 #pragma once
 
-#define APP_VERSION "3.6.0"
-
+#define APP_VERSION "3.6.1"


### PR DESCRIPTION
### New Features
- **Radio Sender TCP service** — added a new TCP service for broadcasting run data, with start/stop controls in the UI (`RadioSender` widget and plugin).
- **Gate crossing timestamps** — runs now record start/finish gate times, used for stage time calculation.
- **Runs table column visibility** — columns can be shown/hidden and the selection is persisted in settings.
- **Color-coding in Runs table** — gate time cells are color-coded based on timing tolerance.

### Refactoring
- **Stage time calculation** delegated to `RunsPlugin` (previously spread across callers).
- **`RadioSender` UI** and `RunsTableModel` refactored for clarity.
- **Time formatting** improved: `TimeMs::toString()` uses `/` as ms separator when needed; default formatting applied consistently across the UI.
- **`RunsTableItemDelegate`** extended to support editing run time fields directly in the table.
- **`qxsql`** — queries now order by `id` and use exact id lookup when `LIMIT 1`.

### Cleanup
- Removed unused `oneTenthSecResults` config/UI option.
- Removed superfluous headers.
- Fixed linter errors.
- Added Zed `settings.json` with `hard_tabs` enabled.