### PR TITLE
Fix Windows automatic deploy of mingw core libraries

### DIFF
--- a/.github/actions/cmake/action.yml
+++ b/.github/actions/cmake/action.yml
@@ -23,7 +23,7 @@ runs:
     # Linux deps
     - name: Install/cache clazy, ninja, openldap, doctest libfuse, and Qt's dependencies
       if: runner.os != 'Windows'
-      uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+      uses: awalsh128/cache-apt-pkgs-action@v1.6.3
       with:
         packages: ninja-build libgl1-mesa-dev libpulse-dev libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-util1 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev clazy libfuse-dev libgstreamer-gl1.0-0 libgstreamer-plugins-base1.0-0
         version: 1.0

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -82,7 +82,9 @@ jobs:
       - name: Copy MinGW runtime libraries
         # windeployqt is unable to copy those, because it looks for them next to where g++.exe is. On the GitHub runner,
         # they are in a different directory.
-        run: cp /mingw64/bin/{libstdc++-6.dll,libgcc_s_seh-1.dll,libwinpthread-1.dll} '${{ github.workspace }}/install/bin'
+        run: |
+          cd "${{github.workspace}}\mingw64\bin"
+          cp {libstdc++-6.dll,libgcc_s_seh-1.dll,libwinpthread-1.dll} '${{ github.workspace }}/install/bin'
         shell: bash
 
       - name: Copy PostgreSQL runtime libraries
@@ -105,3 +107,14 @@ jobs:
         with:
           name: quickevent-${{ env.VERSION }}-setup.exe
           path: ${{ github.workspace }}/install/_inno/quickevent/quickevent-*-setup.exe
+
+      - name: Create 7zip
+        shell: pwsh
+        run: 7z a -t7z -mx=9 ${{ github.workspace }}/install/quickevent-${{ env.VERSION }}.7z ${{ github.workspace }}/install/bin/*
+
+      - name: Upload 7zip
+        uses: actions/upload-artifact@v7
+        with:
+          name: quickevent-${{ env.VERSION }}.7z
+          path: ${{ github.workspace }}/install/quickevent-${{ env.VERSION }}.7z
+          archive: false


### PR DESCRIPTION
Fix deploy of mingw core libraries (`libstdc++-6.dll`, `libgcc_s_seh-1.dll` and `libwinpthread-1.dll`) from correct mingw folder.
Add 7zip package to windows for running without instalation.

Update awalsh128/cache-apt-pkgs-action to v1.6.3

Fix issue #1183